### PR TITLE
DuckDuckGo Search Update

### DIFF
--- a/agixt/AGiXT.py
+++ b/agixt/AGiXT.py
@@ -7,8 +7,10 @@ import spacy
 from datetime import datetime
 from Agent import Agent
 from CustomPrompt import CustomPrompt
-from duckduckgo_search import ddg
+from duckduckgo_search import DDGS
 from urllib.parse import urlparse
+
+ddgs = DDGS()
 
 
 class AGiXT:
@@ -464,6 +466,14 @@ class AGiXT:
         results = results.split("\n")
         for result in results:
             search_string = result.lstrip("0123456789. ")
-            links = ddg(search_string, max_results=depth)
+            try:
+                links = ddgs.text(search_string)
+                if len(links) > depth:
+                    links = links[:depth]
+            except:
+                print(
+                    "Duck Duck Go Search module broke. You may need to try to do `pip install duckduckgo_search --upgrade` to fix this."
+                )
+                links = None
             if links is not None:
                 await resursive_browsing(task, links)

--- a/agixt/commands/google.py
+++ b/agixt/commands/google.py
@@ -1,7 +1,9 @@
 from typing import Union, List
 import json
-from duckduckgo_search import ddg
+from duckduckgo_search import DDGS
 from Commands import Commands
+
+ddgs = DDGS()
 
 
 class google(Commands):
@@ -18,7 +20,15 @@ class google(Commands):
         search_results = []
         if not query:
             return json.dumps(search_results)
-        results = ddg(query, max_results=num_results)
+        try:
+            results = ddgs.text(query)
+            if len(results) > num_results:
+                results = results[:num_results]
+        except:
+            print(
+                "Duck Duck Go Search module broke. You may need to try to do `pip install duckduckgo_search --upgrade` to fix this."
+            )
+            results = None
         if not results:
             return json.dumps(search_results)
         for j in results:


### PR DESCRIPTION
- DuckDuckGo Search module introduced breaking changes with their last update that broke the search and changed all of the function names to use the search..
- Updated references in `AGiXT.py` and `commands/google.py`


The following is **REQUIRED** if you already have AGiXT installed.
```
pip install duckduckgo_search --upgrade
```