### PR TITLE
Migrate from DDG search to Searxng

### DIFF
--- a/agixt/AGiXT.py
+++ b/agixt/AGiXT.py
@@ -8,11 +8,9 @@ import spacy
 from datetime import datetime
 from Agent import Agent
 from CustomPrompt import CustomPrompt
-from duckduckgo_search import DDGS
+from commands.searxng_commands import searxng_commands
 from urllib.parse import urlparse
 import logging
-
-ddgs = DDGS()
 
 
 class AGiXT:
@@ -464,7 +462,10 @@ class AGiXT:
             if links is not None:
                 for link in links:
                     if "href" in link:
-                        url = link["href"]
+                        try:
+                            url = link["href"]
+                        except:
+                            url = link
                     else:
                         url = link
                     url = re.sub(r"^.*?(http)", r"http", url)
@@ -499,13 +500,10 @@ class AGiXT:
         for result in results:
             search_string = result.lstrip("0123456789. ")
             try:
-                links = ddgs.text(search_string)
+                links = searxng_commands().search_searx(search_string)
                 if len(links) > depth:
                     links = links[:depth]
             except:
-                logging.info(
-                    "Duck Duck Go Search module broke. You may need to try to do `pip install duckduckgo_search --upgrade` to fix this."
-                )
                 links = None
             if links is not None:
                 await resursive_browsing(task, links)

--- a/agixt/commands/searxng_commands.py
+++ b/agixt/commands/searxng_commands.py
@@ -1,4 +1,3 @@
-# pip install searx
 import json
 import random
 import requests
@@ -21,7 +20,7 @@ class searxng_commands(Commands):
         except:
             return ["https://searx.work"]
 
-    def search_searx(self, query: str, category: str = "general") -> List[str]:
+    def search_searx(self, query: str) -> List[str]:
         if self.SEARXNG_INSTANCE_URL == "":
             searx = self.searx_servers()
             # Pick a random searx server to use since one was not defined.
@@ -31,7 +30,6 @@ class searxng_commands(Commands):
             self.SEARXNG_INSTANCE_URL = self.SEARXNG_INSTANCE_URL.rstrip("/")
         payload = {
             "q": query,
-            "categories": category,
             "language": "en",
             "safesearch": 1,
             "format": "json",


### PR DESCRIPTION
Migrate from DDG search to Searxng
- DDG provider has been unreliable on a daily basis, searxng has a number of servers that we can randomly search on.
- Build randomized server selection feature in case the `SEARXNG_INSTANCE_URL` is left blank in agent settings. You can find a list of these at https://searx.space/