### PR TITLE
Fix memory issues.

### DIFF
--- a/agixt/Embedding.py
+++ b/agixt/Embedding.py
@@ -101,14 +101,14 @@ class Embedding:
     async def default(self):
         chunk_size = 128
         embed = HuggingFaceTextEmbedding(
-            model_name="all-mpnet-base-v2", log=logging
+            model_id="all-mpnet-base-v2", log=logging
         ).generate_embeddings_async
         return embed, chunk_size
 
     async def large_local(self):
         chunk_size = 500
         embed = HuggingFaceTextEmbedding(
-            model_name="gtr-t5-large", log=logging
+            model_id="gtr-t5-large", log=logging
         ).generate_embeddings_async
         return embed, chunk_size
 

--- a/agixt/Memories.py
+++ b/agixt/Memories.py
@@ -33,7 +33,7 @@ class Memories:
         self.chroma_client = ChromaMemoryStore(
             persist_directory=memories_dir,
             client_settings=Settings(
-                chroma_db_impl="duckdb+parquet",
+                chroma_db_impl="chromadb.db.duckdb.PersistentDuckDB",
                 persist_directory=memories_dir,
                 anonymized_telemetry=False,
             ),

--- a/agixt/test-memory.ipynb
+++ b/agixt/test-memory.ipynb
@@ -2,16 +2,19 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-05-31 14:12:21,424 | INFO | loaded in 1 embeddings\n",
-      "2023-05-31 14:12:21,425 | INFO | loaded in 1 collections\n",
-      "2023-05-31 14:12:21,425 | INFO | Persisting DB to disk, putting it in the save folder: /home/josh/josh/Repos/AGiXT/agixt/agents/OpenAI/memories\n"
+      "2023-06-03 07:51:42,918 | INFO | Successfully imported ClickHouse Connect C data optimizations\n",
+      "2023-06-03 07:51:42,919 | INFO | Successfully import ClickHouse Connect C/Numpy optimizations\n",
+      "2023-06-03 07:51:42,921 | INFO | Using orjson library for writing JSON byte strings\n",
+      "2023-06-03 07:51:42,941 | INFO | loaded in 1 embeddings\n",
+      "2023-06-03 07:51:42,942 | INFO | loaded in 1 collections\n",
+      "2023-06-03 07:51:42,942 | INFO | Persisting DB to disk, putting it in the save folder: /home/josh/josh/Repos/AGiXT/agixt/agents/OpenAI/memories\n"
      ]
     }
    ],
@@ -20,55 +23,100 @@
     "\n",
     "agent_name = \"OpenAI\"\n",
     "agent = Agent(agent_name=agent_name)\n",
-    "agent_config = agent.agent_config\n"
+    "agent_config = agent.agent_config\n",
+    "memories = agent.get_memories()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
-    "collection = await agent.memories.get_collection()"
+    "collection = await memories.get_collection()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-05-31 14:12:13,158 | INFO | message='OpenAI API response' path=https://api.openai.com/v1/embeddings processing_ms=323 request_id=b9ac567f398ba8a5aa06179083deaf9a response_code=200\n",
-      "2023-05-31 14:12:13,169 | INFO | Persisting DB to disk, putting it in the save folder: /home/josh/josh/Repos/AGiXT/agixt/agents/OpenAI/memories\n",
-      "2023-05-31 14:12:13,182 | INFO | Persisting DB to disk, putting it in the save folder: /home/josh/josh/Repos/AGiXT/agixt/agents/OpenAI/memories\n"
+      "2023-06-03 07:49:45,764 | INFO | Load pretrained SentenceTransformer: all-mpnet-base-v2\n",
+      "2023-06-03 07:49:46,725 | INFO | Generating embeddings for 11 texts\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9829cbc7ed1a44c19798cff243033f1a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-06-03 07:49:46,755 | INFO | Persisting DB to disk, putting it in the save folder: /home/josh/josh/Repos/AGiXT/agixt/agents/OpenAI/memories\n",
+      "2023-06-03 07:49:46,774 | INFO | Persisting DB to disk, putting it in the save folder: /home/josh/josh/Repos/AGiXT/agixt/agents/OpenAI/memories\n",
+      "2023-06-03 07:49:46,818 | INFO | Failed to close chroma client: 'LocalAPI' object has no attribute 'close'\n"
      ]
     }
    ],
    "source": [
-    "await agent.memories.store_memory(\n",
+    "await memories.store_memory(\n",
     "    content=\"Test Memory\", description=\"Test Memory\", external_source_name=\"Test Memory\"\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-05-31 14:12:26,605 | INFO | message='OpenAI API response' path=https://api.openai.com/v1/embeddings processing_ms=308 request_id=26065e04fb5fb09b5e984325b77c666b response_code=200\n",
-      "2023-05-31 14:12:26,858 | INFO | CONTEXT: ['Test Memory']\n"
+      "2023-06-03 07:51:49,047 | INFO | Load pretrained SentenceTransformer: all-mpnet-base-v2\n",
+      "2023-06-03 07:51:49,727 | INFO | Generating embeddings for 11 texts\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "298ace1d5a8d41a7b6a17c0972d0fa4c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-06-03 07:51:49,753 | INFO | Load pretrained SentenceTransformer: all-mpnet-base-v2\n",
+      "2023-06-03 07:51:50,554 | INFO | CONTEXT: ['Test Memory']\n"
      ]
     }
    ],
    "source": [
-    "mems = await agent.memories.context_agent(query=\"Test Memory\", top_results_num=1)"
+    "mems = await memories.context_agent(query=\"Test Memory\", top_results_num=1)"
    ]
   },
   {


### PR DESCRIPTION
- `chroma_db_impl` needs to be `chromadb.db.duckdb.PersistentDuckDB` rather than `duckdb+parquet`, confirmed it only works that way with the latest version of Chroma and Semantic Kernel.
- Huggging Face embedder in Semantic Kernel uses `model_id` rather than `model_name` for the model name, updated ref to fix broken embedder.