### PR TITLE
Add Prompt Agent feature

### DIFF
--- a/agixt/app.py
+++ b/agixt/app.py
@@ -44,6 +44,14 @@ class AgentNewName(BaseModel):
     new_name: str
 
 
+class AgentPrompt(BaseModel):
+    prompt_name: str
+    prompt_args: dict
+    websearch: bool
+    websearch_depth: int
+    context_results: int
+
+
 class Objective(BaseModel):
     objective: str
 
@@ -253,6 +261,23 @@ async def instruct(agent_name: str, prompt: Prompt):
     response = await agent.run(
         task=prompt.prompt,
         prompt="instruct",
+    )
+    return {"response": str(response)}
+
+
+@app.post("/api/agent/{agent_name}/prompt", tags=["Agent"])
+async def prompt_agent(agent_name: str, agent_prompt: AgentPrompt):
+    agent = AGiXT(agent_name=agent_name)
+    task = (
+        agent_prompt.prompt_args["task"] if "task" in agent_prompt.prompt_args else ""
+    )
+    response = await agent.run(
+        task=task,
+        prompt=agent_prompt.prompt_name,
+        websearch=agent_prompt.websearch,
+        websearch_depth=agent_prompt.websearch_depth,
+        context_results=agent_prompt.context_results,
+        **agent_prompt.prompt_args,
     )
     return {"response": str(response)}
 

--- a/streamlit/ApiClient.py
+++ b/streamlit/ApiClient.py
@@ -81,6 +81,27 @@ class ApiClient:
         return response.json()["message"]
 
     @staticmethod
+    def prompt_agent(
+        agent_name: str,
+        prompt_name: int,
+        prompt_args: dict,
+        websearch: bool = False,
+        websearch_depth: int = 3,
+        context_results: int = 5,
+    ) -> str:
+        response = requests.post(
+            f"{base_uri}/api/agent/{agent_name}/prompt",
+            json={
+                "prompt_name": prompt_name,
+                "prompt_args": prompt_args,
+                "websearch": websearch,
+                "websearch_depth": websearch_depth,
+                "context_results": context_results,
+            },
+        )
+        return response.json()["response"]
+
+    @staticmethod
     def instruct(agent_name: str, prompt: str) -> str:
         response = requests.post(
             f"{base_uri}/api/agent/{agent_name}/instruct",

--- a/tests/ApiClient.py
+++ b/tests/ApiClient.py
@@ -81,6 +81,27 @@ class ApiClient:
         return response.json()["message"]
 
     @staticmethod
+    def prompt_agent(
+        agent_name: str,
+        prompt_name: int,
+        prompt_args: dict,
+        websearch: bool = False,
+        websearch_depth: int = 3,
+        context_results: int = 5,
+    ) -> str:
+        response = requests.post(
+            f"{base_uri}/api/agent/{agent_name}/prompt",
+            json={
+                "prompt_name": prompt_name,
+                "prompt_args": prompt_args,
+                "websearch": websearch,
+                "websearch_depth": websearch_depth,
+                "context_results": context_results,
+            },
+        )
+        return response.json()["response"]
+
+    @staticmethod
     def instruct(agent_name: str, prompt: str) -> str:
         response = requests.post(
             f"{base_uri}/api/agent/{agent_name}/instruct",

--- a/tests/tests.ipynb
+++ b/tests/tests.ipynb
@@ -416,6 +416,71 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prompt the Agent\n",
+    "\n",
+    "Use a custom Prompt Template to prompt the agent. For our example, we'll use our \"Write a Poem\" prompt template to have the agent write a poem for us about dragons.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Agent prompt response: Majestic beasts with scales as black as night,\n",
+      "With wings that spread to blot out the light,\n",
+      "Their fiery breath could melt steel with ease,\n",
+      "As they soared through the skies with effortless ease.\n",
+      "\n",
+      "Their eyes were like jewels, glittering bright,\n",
+      "As they hunted for prey in the dead of night,\n",
+      "Their roars echoed through the mountains and glades,\n",
+      "Filling hearts with fear, as they sought to evade.\n",
+      "\n",
+      "For Dragons were creatures of legend and myth,\n",
+      "Of fire and power, their strength to outwit,\n",
+      "Their wisdom unmatched, in all that they knew,\n",
+      "And their majesty commanded all to be true.\n",
+      "\n",
+      "From the depths of the earth to the heights of the skies,\n",
+      "They reigned over kingdoms, with piercing, unflinching eyes,\n",
+      "And those fortunate enough to glimpse a Dragon's lair,\n",
+      "Knew there was nothing more magical, powerful or rare.\n",
+      "\n",
+      "So, may we all bow in reverence and awe,\n",
+      "To the mighty Dragons, forevermore,\n",
+      "For they are the guardians of secrets untold,\n",
+      "And their tales will be passed down, for centuries to be told.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from ApiClient import ApiClient\n",
+    "\n",
+    "# Test prompt_agent()\n",
+    "agent_name = \"new_agent\"\n",
+    "prompt_name = \"Write a Poem\"\n",
+    "# The \"Write a Poem\" prompt only requires one argument, \"subject\".\n",
+    "# We'll ask the AI to write a poem about dragons.\n",
+    "prompt_args = {\"subject\": \"dragons\"}\n",
+    "agent_prompt_resp = ApiClient.prompt_agent(\n",
+    "    agent_name=agent_name,\n",
+    "    prompt_name=prompt_name,\n",
+    "    prompt_args=prompt_args,\n",
+    "    websearch=False,\n",
+    "    context_results=0,\n",
+    ")\n",
+    "print(\"Agent prompt response:\", agent_prompt_resp)\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 26,
    "metadata": {},

--- a/tests/tests.ipynb
+++ b/tests/tests.ipynb
@@ -44,7 +44,7 @@
     "\n",
     "# Test get_providers()\n",
     "providers = ApiClient.get_providers()\n",
-    "print(\"Providers:\", providers)\n"
+    "print(\"Providers:\", providers)"
    ]
   },
   {
@@ -76,7 +76,7 @@
     "# Test get_provider_settings()\n",
     "provider_name = \"gpt4free\"\n",
     "provider_settings = ApiClient.get_provider_settings(provider_name=provider_name)\n",
-    "print(f\"Settings for {provider_name}:\", provider_settings)"
+    "print(f\"Settings for {provider_name}:\", provider_settings)\n"
    ]
   },
   {
@@ -107,7 +107,7 @@
     "\n",
     "# Test get_embed_providers()\n",
     "embed_providers = ApiClient.get_embed_providers()\n",
-    "print(\"Embed Providers:\", embed_providers)"
+    "print(\"Embed Providers:\", embed_providers)\n"
    ]
   },
   {
@@ -138,7 +138,7 @@
     "\n",
     "# Test get_extension_settings()\n",
     "ext_settings_resp = ApiClient.get_extension_settings()\n",
-    "print(\"Extension Settings response:\", ext_settings_resp)\n"
+    "print(\"Extension Settings response:\", ext_settings_resp)"
    ]
   },
   {
@@ -169,7 +169,7 @@
     "\n",
     "# Test get_agents()\n",
     "agents = ApiClient.get_agents()\n",
-    "print(\"Agents:\", agents)\n"
+    "print(\"Agents:\", agents)"
    ]
   },
   {
@@ -205,7 +205,7 @@
     "# We'll use defaults for the provider instead of defining anything for the tests.\n",
     "provider_settings = ApiClient.get_provider_settings(provider_name=provider_name)\n",
     "add_agent_resp = ApiClient.add_agent(agent_name=agent_name, settings=provider_settings)\n",
-    "print(\"Add agent response:\", add_agent_resp)"
+    "print(\"Add agent response:\", add_agent_resp)\n"
    ]
   },
   {
@@ -240,7 +240,7 @@
     "rename_agent_resp = ApiClient.rename_agent(\n",
     "    agent_name=agent_name, new_name=new_agent_name\n",
     ")\n",
-    "print(\"Rename agent response:\", rename_agent_resp)"
+    "print(\"Rename agent response:\", rename_agent_resp)\n"
    ]
   },
   {
@@ -272,7 +272,7 @@
     "# Test get_agentconfig()\n",
     "agent_name = \"new_agent\"\n",
     "agent_config = ApiClient.get_agentconfig(agent_name=agent_name)\n",
-    "print(f\"Config for {agent_name}:\", agent_config)\n"
+    "print(f\"Config for {agent_name}:\", agent_config)"
    ]
   },
   {
@@ -313,7 +313,7 @@
     ")\n",
     "print(\"Update agent settings response:\", update_agent_settings_resp)\n",
     "agent_config = ApiClient.get_agentconfig(agent_name=agent_name)\n",
-    "print(f\"New config for {agent_name}:\", agent_config)\n"
+    "print(f\"New config for {agent_name}:\", agent_config)"
    ]
   },
   {
@@ -345,7 +345,7 @@
     "# Test get_commands()\n",
     "agent_name = \"new_agent\"\n",
     "commands = ApiClient.get_commands(agent_name=agent_name)\n",
-    "print(\"Commands:\", commands)\n"
+    "print(\"Commands:\", commands)"
    ]
   },
   {
@@ -378,7 +378,7 @@
     "toggle_command_resp = ApiClient.toggle_command(\n",
     "    agent_name=agent_name, command_name=\"Write to File\", enable=True\n",
     ")\n",
-    "print(\"Toggle command response:\", toggle_command_resp)"
+    "print(\"Toggle command response:\", toggle_command_resp)\n"
    ]
   },
   {
@@ -412,7 +412,7 @@
     "chat_resp = ApiClient.chat(\n",
     "    agent_name=agent_name, prompt=\"What is the capital of France?\"\n",
     ")\n",
-    "print(\"Chat response:\", chat_resp)"
+    "print(\"Chat response:\", chat_resp)\n"
    ]
   },
   {
@@ -475,6 +475,7 @@
     "    prompt_name=prompt_name,\n",
     "    prompt_args=prompt_args,\n",
     "    websearch=False,\n",
+    "    websearch_depth=0\n",
     "    context_results=0,\n",
     ")\n",
     "print(\"Agent prompt response:\", agent_prompt_resp)\n"
@@ -500,7 +501,7 @@
     "# agent_name = \"new_agent\"\n",
     "# smartchat_resp = ApiClient.smartchat(agent_name=agent_name, shots=3, prompt=\"Tell me the capital of France.\")\n",
     "# print(\"Smart chat response:\", smartchat_resp)\n",
-    "print(\"Commented out for sake of saving the long run times in automated tests.\")\n"
+    "print(\"Commented out for sake of saving the long run times in automated tests.\")"
    ]
   },
   {
@@ -543,7 +544,7 @@
     "instruct_resp = ApiClient.instruct(\n",
     "    agent_name=agent_name, prompt=\"Tell me the capital of France.\"\n",
     ")\n",
-    "print(\"Instruct response:\", instruct_resp)"
+    "print(\"Instruct response:\", instruct_resp)\n"
    ]
   },
   {
@@ -566,7 +567,7 @@
     "# agent_name = \"new_agent\"\n",
     "# smartinstruct_resp = ApiClient.smartinstruct(agent_name=agent_name, shots=3, prompt=\"Tell me the capital of France.\")\n",
     "# print(\"Smart instruct response:\", smartinstruct_resp)\n",
-    "print(\"Commented out for sake of saving the long run times in automated tests.\")\n"
+    "print(\"Commented out for sake of saving the long run times in automated tests.\")"
    ]
   },
   {
@@ -598,7 +599,7 @@
     "# Test get_chat_history()\n",
     "agent_name = \"new_agent\"\n",
     "chat_history = ApiClient.get_chat_history(agent_name=agent_name)\n",
-    "print(\"Chat history:\", chat_history)"
+    "print(\"Chat history:\", chat_history)\n"
    ]
   },
   {
@@ -638,7 +639,7 @@
     ")\n",
     "print(\"Update agent commands response:\", update_agent_commands_resp)\n",
     "agent_config = ApiClient.get_agentconfig(agent_name=agent_name)\n",
-    "print(f\"New config for {agent_name}:\", agent_config)\n"
+    "print(f\"New config for {agent_name}:\", agent_config)"
    ]
   },
   {
@@ -670,7 +671,7 @@
     "file_learning = ApiClient.learn_file(\n",
     "    agent_name=agent_name, file_name=\"test.txt\", file_content=\"This is a test file.\"\n",
     ")\n",
-    "print(\"File Learning response:\", file_learning)"
+    "print(\"File Learning response:\", file_learning)\n"
    ]
   },
   {
@@ -700,7 +701,7 @@
     "# Test learn_url()\n",
     "agent_name = \"new_agent\"\n",
     "url_learning = ApiClient.learn_url(agent_name=agent_name, url=\"https://agixt.com\")\n",
-    "print(\"URL Learning response:\", url_learning)\n"
+    "print(\"URL Learning response:\", url_learning)"
    ]
   },
   {
@@ -733,7 +734,7 @@
     "# Note: Use this function with caution as it will erase the agent's memory.\n",
     "agent_name = \"new_agent\"\n",
     "wipe_mem_resp = ApiClient.wipe_agent_memories(agent_name=agent_name)\n",
-    "print(\"Wipe agent memories response:\", wipe_mem_resp)"
+    "print(\"Wipe agent memories response:\", wipe_mem_resp)\n"
    ]
   },
   {
@@ -770,7 +771,7 @@
     "\n",
     "# Test get_chains()\n",
     "chains = ApiClient.get_chains()\n",
-    "print(\"Chains:\", chains)"
+    "print(\"Chains:\", chains)\n"
    ]
   },
   {
@@ -800,7 +801,7 @@
     "# Test add_chain()\n",
     "chain_name = \"Write another Poem\"\n",
     "add_chain_resp = ApiClient.add_chain(chain_name=chain_name)\n",
-    "print(\"Add chain response:\", add_chain_resp)"
+    "print(\"Add chain response:\", add_chain_resp)\n"
    ]
   },
   {
@@ -833,7 +834,7 @@
     "rename_chain_resp = ApiClient.rename_chain(\n",
     "    chain_name=chain_name, new_name=new_chain_name\n",
     ")\n",
-    "print(\"Rename chain response:\", rename_chain_resp)\n"
+    "print(\"Rename chain response:\", rename_chain_resp)"
    ]
   },
   {
@@ -885,7 +886,7 @@
     "        \"subject\": \"Quantum Computers\",\n",
     "    },\n",
     ")\n",
-    "print(\"Add step response:\", add_step_resp)\n"
+    "print(\"Add step response:\", add_step_resp)"
    ]
   },
   {
@@ -915,7 +916,7 @@
     "# Test get_chain()\n",
     "chain_name = \"Poem Writing Chain\"\n",
     "chain = ApiClient.get_chain(chain_name=chain_name)\n",
-    "print(\"Chain:\", chain)"
+    "print(\"Chain:\", chain)\n"
    ]
   },
   {
@@ -957,7 +958,7 @@
     "        \"subject\": \"Artificial General Intelligence\",\n",
     "    },\n",
     ")\n",
-    "print(\"Update step response:\", update_step_resp)\n"
+    "print(\"Update step response:\", update_step_resp)"
    ]
   },
   {
@@ -993,7 +994,7 @@
     "move_step_resp = ApiClient.move_step(\n",
     "    chain_name=chain_name, old_step_number=1, new_step_number=2\n",
     ")\n",
-    "print(\"Move step response:\", move_step_resp)\n"
+    "print(\"Move step response:\", move_step_resp)"
    ]
   },
   {
@@ -1023,7 +1024,7 @@
     "# Test run_chain()\n",
     "chain_name = \"Poem Writing Chain\"\n",
     "run_chain_resp = ApiClient.run_chain(chain_name=chain_name)\n",
-    "print(\"Run chain response:\", run_chain_resp)"
+    "print(\"Run chain response:\", run_chain_resp)\n"
    ]
   },
   {
@@ -1054,7 +1055,7 @@
     "# Test get_chain()\n",
     "chain_name = \"Poem Writing Chain\"\n",
     "chain = ApiClient.get_chain_responses(chain_name=chain_name)\n",
-    "print(\"Chain:\", chain)"
+    "print(\"Chain:\", chain)\n"
    ]
   },
   {
@@ -1084,7 +1085,7 @@
     "# Test delete_step()\n",
     "chain_name = \"Poem Writing Chain\"\n",
     "delete_step_resp = ApiClient.delete_step(chain_name=chain_name, step_number=2)\n",
-    "print(\"Delete step response:\", delete_step_resp)"
+    "print(\"Delete step response:\", delete_step_resp)\n"
    ]
   },
   {
@@ -1114,7 +1115,7 @@
     "# Test delete_chain()\n",
     "chain_name = \"Poem Writing Chain\"\n",
     "delete_chain_resp = ApiClient.delete_chain(chain_name=chain_name)\n",
-    "print(\"Delete chain response:\", delete_chain_resp)"
+    "print(\"Delete chain response:\", delete_chain_resp)\n"
    ]
   },
   {
@@ -1145,7 +1146,7 @@
     "\n",
     "# Test get_prompts()\n",
     "prompts = ApiClient.get_prompts()\n",
-    "print(\"Prompts:\", prompts)"
+    "print(\"Prompts:\", prompts)\n"
    ]
   },
   {
@@ -1178,7 +1179,7 @@
     "add_prompt_resp = ApiClient.add_prompt(\n",
     "    prompt_name=\"Short Story\", prompt=\"Tell me a short story about {subject}\"\n",
     ")\n",
-    "print(\"Add prompt response:\", add_prompt_resp)\n"
+    "print(\"Add prompt response:\", add_prompt_resp)"
    ]
   },
   {
@@ -1207,7 +1208,7 @@
     "\n",
     "# Test get_prompt()\n",
     "get_prompt_resp = ApiClient.get_prompt(prompt_name=\"Short Story\")\n",
-    "print(\"Get prompt response:\", get_prompt_resp)"
+    "print(\"Get prompt response:\", get_prompt_resp)\n"
    ]
   },
   {
@@ -1237,7 +1238,7 @@
     "\n",
     "# Test get_prompt_args()\n",
     "get_prompt_args_resp = ApiClient.get_prompt_args(prompt_name=\"Short Story\")\n",
-    "print(\"Get prompt args response:\", get_prompt_args_resp)\n"
+    "print(\"Get prompt args response:\", get_prompt_args_resp)"
    ]
   },
   {
@@ -1271,7 +1272,7 @@
     "    prompt_name=\"Short Story\",\n",
     "    prompt=\"Tell me a short story about {subject}. Add a dragon to the story somehow.\",\n",
     ")\n",
-    "print(\"Update prompt response:\", update_prompt_resp)\n"
+    "print(\"Update prompt response:\", update_prompt_resp)"
    ]
   },
   {
@@ -1302,7 +1303,7 @@
     "\n",
     "# Test delete_prompt()\n",
     "delete_prompt_resp = ApiClient.delete_prompt(prompt_name=\"Short Story\")\n",
-    "print(\"Delete prompt response:\", delete_prompt_resp)"
+    "print(\"Delete prompt response:\", delete_prompt_resp)\n"
    ]
   },
   {
@@ -1340,7 +1341,7 @@
     "\n",
     "print(\n",
     "    \"Commented out for now, this is in a potentially infinite loop that will need to be evaluated before further testing.\"\n",
-    ")"
+    ")\n"
    ]
   },
   {
@@ -1372,7 +1373,7 @@
     "# Test get_task_status()\n",
     "agent_name = \"new_agent\"\n",
     "task_status = ApiClient.get_task_status(agent_name=agent_name)\n",
-    "print(\"Task status:\", task_status)"
+    "print(\"Task status:\", task_status)\n"
    ]
   },
   {
@@ -1404,7 +1405,7 @@
     "# Test get_task_output()\n",
     "agent_name = \"new_agent\"\n",
     "task_output = ApiClient.get_task_output(agent_name=agent_name)\n",
-    "print(\"Task output:\", task_output)"
+    "print(\"Task output:\", task_output)\n"
    ]
   },
   {
@@ -1434,7 +1435,7 @@
     "# Test get_task_output()\n",
     "agent_name = \"new_agent\"\n",
     "task_output = ApiClient.get_tasks(agent_name=agent_name)\n",
-    "print(\"Task output:\", task_output)"
+    "print(\"Task output:\", task_output)\n"
    ]
   },
   {
@@ -1466,7 +1467,7 @@
     "# Test delete_agent()\n",
     "agent_name = \"new_agent\"\n",
     "delete_agent_resp = ApiClient.delete_agent(agent_name=agent_name)\n",
-    "print(\"Delete agent response:\", delete_agent_resp)"
+    "print(\"Delete agent response:\", delete_agent_resp)\n"
    ]
   }
  ],


### PR DESCRIPTION
# Description

Added a `Prompt Agent` feature to allow users to:
- Use a Prompt Template to choose a prompt name and a dictionary of the variables for that prompt.
- Choose to browse the web for context prior to answering and the depth of the web search.
- Choose how many context results to inject from memory (only works if you have `{context}` and `{task}` in your prompt template! The `task` is the search string for the AI to look for context on.)

## Motivation and Context

Opens up what is available in the API to enable more flexibility.

## How has this been tested?

Added to `tests.ipynb` for the automated testing in the repo as well as testing locally with results in the PR.

## Screenshots (if appropriate)

![image](https://github.com/Josh-XT/AGiXT/assets/102809327/5786bb59-f473-4b0d-b2e9-52bc88687743)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] My change works!
