### PR TITLE
Add Custom OpenAI Style Provider

### DIFF
--- a/agixt/provider/custom.py
+++ b/agixt/provider/custom.py
@@ -1,0 +1,60 @@
+import requests
+
+
+# Custom OpenAI Style Provider
+class CustomProvider:
+    def __init__(
+        self,
+        API_KEY: str = "",
+        API_URI: str = "https://api.openai.com/v1/engines/davinci/completions",
+        AI_MODEL: str = "gpt-3.5-turbo",
+        AI_TEMPERATURE: float = 0.7,
+        AI_TOP_P: float = 0.7,
+        MAX_TOKENS: int = 4096,
+        **kwargs,
+    ):
+        self.requirements = ["requests"]
+        self.AI_MODEL = AI_MODEL
+        self.AI_TEMPERATURE = AI_TEMPERATURE
+        self.AI_TOP_P = AI_TOP_P
+        self.MAX_TOKENS = MAX_TOKENS
+        self.API_KEY = API_KEY
+        self.API_URI = API_URI
+
+    async def instruct(self, prompt, tokens: int = 0):
+        max_new_tokens = int(self.MAX_TOKENS) - tokens
+        if not self.AI_MODEL.startswith("gpt-"):
+            # Use completion API
+            params = {
+                "prompt": prompt,
+                "temperature": float(self.AI_TEMPERATURE),
+                "max_tokens": max_new_tokens,
+                "top_p": float(self.AI_TOP_P),
+                "frequency_penalty": 0,
+                "presence_penalty": 0,
+            }
+        else:
+            # Use chat completion API
+            params = {
+                "prompt": prompt,
+                "temperature": float(self.AI_TEMPERATURE),
+                "max_tokens": max_new_tokens,
+                "top_p": float(self.AI_TOP_P),
+                "n": 1,
+                "stop": None,
+            }
+
+        response = requests.post(
+            self.API_URI,
+            headers={"Authorization": f"Bearer {self.API_KEY}"},
+            json=params,
+        )
+        data = response.json()
+        if data:
+            if "choices" in data:
+                if data["choices"]:
+                    if "text" in data["choices"][0]:
+                        return data["choices"][0]["text"].strip()
+                    if "message" in data["choices"][0]:
+                        return data["choices"][0]["message"]["content"].strip()
+            return data

--- a/docs/3-Providers/Azure OpenAI.md
+++ b/docs/3-Providers/Azure OpenAI.md
@@ -13,5 +13,5 @@
 5. Set `AZURE_OPENAI_ENDPOINT` to your Azure OpenAI endpoint.
 6. Choose your `AI_MODEL`.  Enter `gpt-3.5-turbo`, `gpt-4`, `gpt-4-32k`, or any other model you may have access to.
 7. Set `AI_TEMPERATURE` to a value between 0 and 1. The higher the value, the more creative the output.
-8. Set `MAX_TOKENS` to the maximum number of tokens to generate. The higher the value, the longer the output.  The maximum for `gpt-3.5-turbo` is 4096, `gpt-4` is 8192, `gpt-4-32k` is 32768.
+8. Set `MAX_TOKENS` to the maximum number of tokens to generate. The higher the value, the longer the output.  The maximum for `gpt-3.5-turbo` is 4096, `gpt-4` is 8192, `gpt-4-32k` is 32768, `gpt-3.5-turbo-16k` is 16000.
 

--- a/docs/3-Providers/Custom OpenAI Style Provider.md
+++ b/docs/3-Providers/Custom OpenAI Style Provider.md
@@ -1,0 +1,15 @@
+# Custom OpenAI Style Provider
+- Listed as `custom` in the provider list.
+- [AGiXT](https://github.com/Josh-XT/AGiXT)
+
+This provider enables you to use OpenAI proxies as well as custom endpoints that utilize the same syntax as OpenAI's API.
+
+## Quick Start Guide
+### Update your agent settings
+1. Set `AI_PROVIDER` to `custom`.
+2. Set `API_URI` to the URI of your endpoint. For example, `https://api.openai.com/v1/engines/davinci/completions`.
+3. Set `API_KEY` to the API key for your endpoint if applicable, leave empty if not.
+4. Set `AI_MODEL` to `gpt-3.5-turbo-16k` if that is the model you would prefer to use.
+5. Set `AI_TEMPERATURE` to a value between 0 and 1. The higher the value, the more creative the output.
+6. Set `AP_TOP_P` to a value between 0 and 1, generally keeping this closer to 1 is better.
+7. Set `MAX_TOKENS` to the maximum number of tokens to generate. The higher the value, the longer the output.  The maximum for `gpt-3.5-turbo` is 4000, `gpt-4` is 8000, `gpt-3.5-turbo-16k` is 16000.

--- a/docs/3-Providers/OpenAI.md
+++ b/docs/3-Providers/OpenAI.md
@@ -10,5 +10,5 @@
 2. Set `OPENAI_API_KEY` to your OpenAI API key.
 3. Set `AI_MODEL` to `gpt-3.5-turbo` for ChatGPT.
 4. Set `AI_TEMPERATURE` to a value between 0 and 1. The higher the value, the more creative the output.
-5. Set `MAX_TOKENS` to the maximum number of tokens to generate. The higher the value, the longer the output.  The maximum for `gpt-3.5-turbo` is 4000, `gpt-4` is 8000.
+5. Set `MAX_TOKENS` to the maximum number of tokens to generate. The higher the value, the longer the output.  The maximum for `gpt-3.5-turbo` is 4000, `gpt-4` is 8000, `gpt-3.5-turbo-16k` is 16000.
 


### PR DESCRIPTION
## Add Custom OpenAI Style Provider
Many people are standardizing around using OpenAI endpoints for their providers or utilizing various proxies for various reasons.  The Custom OpenAI Style Provider enables you to use OpenAI proxies as well as custom endpoints that utilize the same syntax as OpenAI's API.