### PR TITLE
Improve chat history

### DIFF
--- a/agixt/Agent.py
+++ b/agixt/Agent.py
@@ -352,15 +352,9 @@ class Agent:
         try:
             with open(self.history_file, "r") as f:
                 yaml_history = yaml.safe_load(f)
-            history = []
-            for interaction in yaml_history["interactions"]:
-                role = interaction["role"]
-                if "timestamp" in interaction:
-                    message = interaction["timestamp"] + "\n" + interaction["message"]
-                else:
-                    message = interaction["message"]
-                history.append({role: message})
-            return history
+            if "interactions" in yaml_history:
+                return yaml_history["interactions"]
+            return []
         except:
             return []
 

--- a/streamlit/components/history.py
+++ b/streamlit/components/history.py
@@ -53,13 +53,18 @@ def get_history(agent_name):
         message_container = "<div class='message-container'>"
 
         for item in history:
-            if "USER" in item.keys():
-                message_container += f"<div class='message user-message'><b>You:</b><br>{item['USER']}</div>"
+            message = (
+                f"{item['timestamp']}<br><b>{item['role']}:</b><br>{item['message']}"
+            )
+
+            if agent_name in item["role"]:
+                message_container += (
+                    f"<div class='message agent-message'>{message}</div>"
+                )
             else:
-                if item[agent_name].startswith(f"{agent_name}:"):
-                    item[agent_name] = item[agent_name][len(agent_name) + 1 :]
-                item[agent_name] = item[agent_name].replace("\n", "<br />")
-                item[agent_name] = html.escape(item[agent_name])
-                message_container += f"<div class='message agent-message'><b>{agent_name}:</b><br/>{item[agent_name]}</div>"
+                message_container += (
+                    f"<div class='message user-message'>{message}</div>"
+                )
+
         message_container += "</div>"
         st.write(message_container, unsafe_allow_html=True)

--- a/streamlit/components/history.py
+++ b/streamlit/components/history.py
@@ -45,28 +45,26 @@ def get_history(agent_name):
     st.write(message_container_css, unsafe_allow_html=True)
 
     with st.container():
-        # Get chat history from API
-        history = ApiClient.get_chat_history(agent_name=agent_name)
-        history = reversed(history)
-
-        # Create a container for messages
         message_container = "<div class='message-container'>"
+        try:
+            history = ApiClient.get_chat_history(agent_name=agent_name)
+            history = reversed(history)
 
-        for item in history:
-            item["message"] = html.escape(item["message"])
-            item["message"] = item["message"].replace(r"\n", "<br>")
-            message = (
-                f"{item['timestamp']}<br><b>{item['role']}:</b><br>{item['message']}"
-            )
+            for item in history:
+                item["message"] = html.escape(item["message"])
+                item["message"] = item["message"].replace(r"\n", "<br>")
+                message = f"{item['timestamp']}<br><b>{item['role']}:</b><br>{item['message']}"
 
-            if agent_name in item["role"]:
-                message_container += (
-                    f"<div class='message agent-message'>{message}</div>"
-                )
-            else:
-                message_container += (
-                    f"<div class='message user-message'>{message}</div>"
-                )
+                if agent_name in item["role"]:
+                    message_container += (
+                        f"<div class='message agent-message'>{message}</div>"
+                    )
+                else:
+                    message_container += (
+                        f"<div class='message user-message'>{message}</div>"
+                    )
 
+        except Exception as e:
+            print(e)
         message_container += "</div>"
         st.write(message_container, unsafe_allow_html=True)

--- a/streamlit/components/history.py
+++ b/streamlit/components/history.py
@@ -53,6 +53,8 @@ def get_history(agent_name):
         message_container = "<div class='message-container'>"
 
         for item in history:
+            item["message"] = html.escape(item["message"])
+            item["message"] = item["message"].replace(r"\n", "<br>")
             message = (
                 f"{item['timestamp']}<br><b>{item['role']}:</b><br>{item['message']}"
             )


### PR DESCRIPTION
Improve chat history
- Added timestamps as their own part of the dictionary return.
- Modified the history component in streamlit to improve it.
- Improved history error handling for when agents might not have a history.