### PR TITLE
Add parameters to run chain endpoint

### DIFF
--- a/ApiClient.ts
+++ b/ApiClient.ts
@@ -258,12 +258,16 @@ export class ApiClient {
   public runChain(
     chainName: string,
     userInput: string,
-    agentName: string = ""
+    agentName: string = "",
+    all_responses: boolean = false,
+    from_step: number = 1
   ): Promise<string> {
     return axios
       .post(`${this.baseUri}/api/chain/${chainName}/run`, {
         prompt: userInput,
         agent_override: agentName,
+        all_responses: all_responses,
+        from_step: from_step,
       })
       .then((response) => response.data);
   }

--- a/agixt/app.py
+++ b/agixt/app.py
@@ -111,6 +111,8 @@ class ChainData(BaseModel):
 class RunChain(BaseModel):
     prompt: str
     agent_override: Optional[str] = ""
+    all_responses: Optional[bool] = False
+    from_step: Optional[int] = 1
 
 
 class StepInfo(BaseModel):
@@ -516,6 +518,8 @@ async def run_chain(chain_name: str, user_input: RunChain):
         chain_name=chain_name,
         user_input=user_input.prompt,
         agent_override=user_input.agent_override,
+        all_responses=user_input.all_responses,
+        from_step=user_input.from_step,
     )
     return chain_response
 

--- a/streamlit/ApiClient.py
+++ b/streamlit/ApiClient.py
@@ -207,10 +207,21 @@ class ApiClient:
         return response.json()["chain"]
 
     @staticmethod
-    def run_chain(chain_name: str, user_input: str, agent_name: str = "") -> str:
+    def run_chain(
+        chain_name: str,
+        user_input: str,
+        agent_name: str = "",
+        all_responses: bool = False,
+        from_step: int = 1,
+    ) -> str:
         response = requests.post(
             f"{base_uri}/api/chain/{chain_name}/run",
-            json={"prompt": user_input, "agent_override": agent_name},
+            json={
+                "prompt": user_input,
+                "agent_override": agent_name,
+                "all_responses": all_responses,
+                "from_step": int(from_step),
+            },
         )
         return response.json()
 

--- a/streamlit/pages/3-Interact.py
+++ b/streamlit/pages/3-Interact.py
@@ -138,6 +138,10 @@ if mode == "Chains":
     chain_names = ApiClient.get_chains()
     chain_action = "Run Chain"
     chain_name = st.selectbox("Chains", chain_names)
+    from_step = st.number_input("Start from Step", min_value=1, value=1)
+    all_responses = st.checkbox(
+        "Show All Responses (If not checked, you will only be shown the last step's response in the chain when done.)"
+    )
     user_input = st.text_area("User Input")
     # Need a checkbox for agent override
     agent_override = st.checkbox("Override Agent")
@@ -149,7 +153,11 @@ if mode == "Chains":
         if chain_name:
             if chain_action == "Run Chain":
                 responses = ApiClient.run_chain(
-                    chain_name=chain_name, user_input=user_input, agent_name=agent_name
+                    chain_name=chain_name,
+                    user_input=user_input,
+                    agent_name=agent_name,
+                    all_responses=all_responses,
+                    from_step=from_step,
                 )
                 st.success(f"Chain '{chain_name}' executed.")
                 st.write(responses)

--- a/streamlit/pages/3-Interact.py
+++ b/streamlit/pages/3-Interact.py
@@ -149,7 +149,7 @@ if mode == "Chains":
         agent_name = agent_selection()
     else:
         agent_name = ""
-    if st.button("Perform Action"):
+    if st.button("Run Chain"):
         if chain_name:
             if chain_action == "Run Chain":
                 responses = ApiClient.run_chain(

--- a/tests/ApiClient.py
+++ b/tests/ApiClient.py
@@ -207,10 +207,21 @@ class ApiClient:
         return response.json()["chain"]
 
     @staticmethod
-    def run_chain(chain_name: str, user_input: str, agent_name: str = "") -> str:
+    def run_chain(
+        chain_name: str,
+        user_input: str,
+        agent_name: str = "",
+        all_responses: bool = False,
+        from_step: int = 1,
+    ) -> str:
         response = requests.post(
             f"{base_uri}/api/chain/{chain_name}/run",
-            json={"prompt": user_input, "agent_override": agent_name},
+            json={
+                "prompt": user_input,
+                "agent_override": agent_name,
+                "all_responses": all_responses,
+                "from_step": int(from_step),
+            },
         )
         return response.json()
 


### PR DESCRIPTION
Add parameters to run chain endpoint
- New parameter `all_responses` is default set to `False`, which will make the chain only return the last response from the last step in the chain to the front end.
- New parameter `from_step` is default set to `1`.  This is useful for if you need to start a chain from a specific step instead of from the first step.  Great for debugging your chains if you don't want to have to run every step every time.