### PR TITLE
Improve OpenAI Provider, Add Helper Agent

### DIFF
--- a/agixt/Embedding.py
+++ b/agixt/Embedding.py
@@ -129,9 +129,13 @@ class Embedding:
         else:
             # Use default if not specified
             embedding_uri = None
+        if "API_KEY" in self.AGENT_CONFIG["settings"]:
+            api_key = self.AGENT_CONFIG["settings"]["API_KEY"]
+        else:
+            api_key = self.AGENT_CONFIG["settings"]["OPENAI_API_KEY"]
         embed = OpenAITextEmbedding(
             model_id="text-embedding-ada-002",
-            api_key=self.AGENT_CONFIG["settings"]["OPENAI_API_KEY"],
+            api_key=api_key,
             endpoint=embedding_uri,
             log=logging,
         ).generate_embeddings_async

--- a/agixt/Embedding.py
+++ b/agixt/Embedding.py
@@ -124,19 +124,14 @@ class Embedding:
 
     async def openai(self):
         chunk_size = 1000
-        if "EMBEDDING_URI" in self.AGENT_CONFIG["settings"]:
-            embedding_uri = self.AGENT_CONFIG["settings"]["EMBEDDING_URI"]
+        if "API_URI" in self.AGENT_CONFIG["settings"]:
+            api_base = self.AGENT_CONFIG["settings"]["API_URI"]
         else:
-            # Use default if not specified
-            embedding_uri = None
-        if "API_KEY" in self.AGENT_CONFIG["settings"]:
-            api_key = self.AGENT_CONFIG["settings"]["API_KEY"]
-        else:
-            api_key = self.AGENT_CONFIG["settings"]["OPENAI_API_KEY"]
+            api_base = None
         embed = OpenAITextEmbedding(
             model_id="text-embedding-ada-002",
-            api_key=api_key,
-            endpoint=embedding_uri,
+            api_key=self.AGENT_CONFIG["settings"]["OPENAI_API_KEY"],
+            endpoint=api_base,
             log=logging,
         ).generate_embeddings_async
         return embed, chunk_size

--- a/agixt/Embedding.py
+++ b/agixt/Embedding.py
@@ -124,9 +124,15 @@ class Embedding:
 
     async def openai(self):
         chunk_size = 1000
+        if "EMBEDDING_URI" in self.AGENT_CONFIG["settings"]:
+            embedding_uri = self.AGENT_CONFIG["settings"]["EMBEDDING_URI"]
+        else:
+            # Use default if not specified
+            embedding_uri = None
         embed = OpenAITextEmbedding(
             model_id="text-embedding-ada-002",
             api_key=self.AGENT_CONFIG["settings"]["OPENAI_API_KEY"],
+            endpoint=embedding_uri,
             log=logging,
         ).generate_embeddings_async
         return embed, chunk_size

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -197,7 +197,13 @@ class Interactions:
             working_directory = self.agent.AGENT_CONFIG["settings"]["WORKING_DIRECTORY"]
         except:
             working_directory = "./WORKSPACE"
-
+        if "helper_agent_name" not in kwargs:
+            if "helper_agent_name" in self.agent.AGENT_CONFIG["settings"]:
+                helper_agent_name = self.agent.AGENT_CONFIG["settings"][
+                    "helper_agent_name"
+                ]
+            else:
+                helper_agent_name = self.agent_name
         formatted_prompt = self.custom_format(
             string=prompt,
             user_input=user_input,
@@ -207,6 +213,7 @@ class Interactions:
             command_list=command_list,
             date=datetime.now().strftime("%B %d, %Y %I:%M %p"),
             working_directory=working_directory,
+            helper_agent_name=helper_agent_name,
             **kwargs,
         )
 

--- a/agixt/chains/Ask Helper Agent for Help.json
+++ b/agixt/chains/Ask Helper Agent for Help.json
@@ -1,0 +1,16 @@
+{
+    "chain_name": "Ask Helper Agent for Help",
+    "steps": [
+        {
+            "step": 1,
+            "agent_name": "gpt4free",
+            "prompt_type": "Command",
+            "prompt": {
+                "command_name": "Generate Agent Helper Chain",
+                "user_agent": "{agent_name}",
+                "helper_agent": "{helper_agent_name}",
+                "task_in_question": "{user_input}"
+            }
+        }
+    ]
+}

--- a/agixt/extensions/agixt_agent.py
+++ b/agixt/extensions/agixt_agent.py
@@ -21,7 +21,6 @@ class agixt_agent(Extensions):
             "Describe Image": self.describe_image,
             "Execute Python Code": self.execute_python_code,
             "Get Python Code from Response": self.get_python_code_from_response,
-            "Ask for Help or Further Clarification to Complete Task": self.ask_for_help,
         }
         if agents != None:
             for agent in agents:
@@ -47,26 +46,6 @@ class agixt_agent(Extensions):
             )
         except Exception as e:
             return f"Unable to create command: {e}"
-
-    async def ask_for_help(
-        self,
-        agent: str,
-        your_primary_objective: str,
-        your_current_task: str,
-        your_detailed_question: str,
-    ) -> str:
-        """
-        Ask for Help or Further Clarification to Complete Task
-        """
-        return await ApiClient.prompt_agent(
-            agent_name=agent,
-            prompt_name="Ask for Help",
-            prompt_args={
-                "user_input": your_primary_objective,
-                "question": your_detailed_question,
-                "task_in_question": your_current_task,
-            },
-        )
 
     async def ask(self, user_input: str, agent: str = "AGiXT") -> str:
         response = ApiClient.prompt_agent(

--- a/agixt/provider/custom.py
+++ b/agixt/provider/custom.py
@@ -9,7 +9,6 @@ class CustomProvider:
         self,
         API_KEY: str = "",
         API_URI: str = "https://api.openai.com/v1/chat/completions",
-        EMBEDDING_URI: str = "https://api.openai.com/v1/embeddings",
         AI_MODEL: str = "gpt-3.5-turbo-16k-0613",
         AI_TEMPERATURE: float = 0.7,
         AI_TOP_P: float = 0.7,
@@ -25,7 +24,6 @@ class CustomProvider:
         self.MAX_TOKENS = MAX_TOKENS if MAX_TOKENS else 16000
         self.API_KEY = API_KEY
         self.API_URI = API_URI
-        self.EMBEDDING_URI = EMBEDDING_URI
         self.WAIT_AFTER_FAILURE = WAIT_AFTER_FAILURE if WAIT_AFTER_FAILURE else 3
         self.WAIT_BETWEEN_REQUESTS = (
             WAIT_BETWEEN_REQUESTS if WAIT_BETWEEN_REQUESTS else 0

--- a/agixt/provider/custom.py
+++ b/agixt/provider/custom.py
@@ -8,7 +8,8 @@ class CustomProvider:
     def __init__(
         self,
         API_KEY: str = "",
-        API_URI: str = "https://api.openai.com/v1/engines/davinci/completions",
+        API_URI: str = "https://api.openai.com/v1/chat/completions",
+        EMBEDDING_URI: str = "https://api.openai.com/v1/embeddings",
         AI_MODEL: str = "gpt-3.5-turbo-16k-0613",
         AI_TEMPERATURE: float = 0.7,
         AI_TOP_P: float = 0.7,
@@ -24,6 +25,7 @@ class CustomProvider:
         self.MAX_TOKENS = MAX_TOKENS if MAX_TOKENS else 16000
         self.API_KEY = API_KEY
         self.API_URI = API_URI
+        self.EMBEDDING_URI = EMBEDDING_URI
         self.WAIT_AFTER_FAILURE = WAIT_AFTER_FAILURE if WAIT_AFTER_FAILURE else 3
         self.WAIT_BETWEEN_REQUESTS = (
             WAIT_BETWEEN_REQUESTS if WAIT_BETWEEN_REQUESTS else 0

--- a/agixt/provider/openai.py
+++ b/agixt/provider/openai.py
@@ -1,4 +1,6 @@
 import openai
+import time
+import logging
 
 
 class OpenaiProvider:
@@ -8,40 +10,48 @@ class OpenaiProvider:
         AI_MODEL: str = "gpt-3.5-turbo-16k-0613",
         AI_TEMPERATURE: float = 0.7,
         AI_TOP_P: float = 0.7,
-        MAX_TOKENS: int = 4096,
-        **kwargs
+        MAX_TOKENS: int = 16384,
+        API_URI: str = "https://api.openai.com/v1",
+        **kwargs,
     ):
         self.requirements = ["openai"]
         self.AI_MODEL = AI_MODEL if AI_MODEL else "gpt-3.5-turbo-16k-0613"
         self.AI_TEMPERATURE = AI_TEMPERATURE if AI_TEMPERATURE else 0.7
         self.AI_TOP_P = AI_TOP_P if AI_TOP_P else 0.7
-        self.MAX_TOKENS = MAX_TOKENS if MAX_TOKENS else 16000
+        self.MAX_TOKENS = MAX_TOKENS if MAX_TOKENS else 16384
+        self.API_URI = API_URI
+        openai.api_base = self.API_URI
         openai.api_key = OPENAI_API_KEY
 
     async def instruct(self, prompt, tokens: int = 0):
         max_new_tokens = int(self.MAX_TOKENS) - tokens
-        if not self.AI_MODEL.startswith("gpt-"):
-            # Use completion API
-            response = openai.Completion.create(
-                engine=self.AI_MODEL,
-                prompt=prompt,
-                temperature=float(self.AI_TEMPERATURE),
-                max_tokens=max_new_tokens,
-                top_p=float(self.AI_TOP_P),
-                frequency_penalty=0,
-                presence_penalty=0,
-            )
-            return response.choices[0].text.strip()
-        else:
-            # Use chat completion API
-            messages = [{"role": "system", "content": prompt}]
-            response = openai.ChatCompletion.create(
-                model=self.AI_MODEL,
-                messages=messages,
-                temperature=float(self.AI_TEMPERATURE),
-                max_tokens=max_new_tokens,
-                top_p=float(self.AI_TOP_P),
-                n=1,
-                stop=None,
-            )
-            return response.choices[0].message.content.strip()
+        try:
+            if not self.AI_MODEL.startswith("gpt-"):
+                # Use completion API
+                response = openai.Completion.create(
+                    engine=self.AI_MODEL,
+                    prompt=prompt,
+                    temperature=float(self.AI_TEMPERATURE),
+                    max_tokens=max_new_tokens,
+                    top_p=float(self.AI_TOP_P),
+                    frequency_penalty=0,
+                    presence_penalty=0,
+                )
+                return response.choices[0].text.strip()
+            else:
+                # Use chat completion API
+                messages = [{"role": "system", "content": prompt}]
+                response = openai.ChatCompletion.create(
+                    model=self.AI_MODEL,
+                    messages=messages,
+                    temperature=float(self.AI_TEMPERATURE),
+                    max_tokens=max_new_tokens,
+                    top_p=float(self.AI_TOP_P),
+                    n=1,
+                    stop=None,
+                )
+                return response.choices[0].message.content.strip()
+        except Exception as e:
+            logging.info(f"OpenAI API Error: {e}")
+            time.sleep(3)
+            return await self.instruct(prompt=prompt, tokens=tokens)

--- a/streamlit/components/selectors.py
+++ b/streamlit/components/selectors.py
@@ -89,7 +89,7 @@ def chain_selection(prompt: dict = {}, step_number: int = 0):
         return new_prompt
 
 
-def agent_selection():
+def agent_selection(key: str = "select_learning_agent", heading: str = "Agent Name"):
     # Load the previously selected agent name
     try:
         with open(os.path.join("session.txt"), "r") as f:
@@ -110,18 +110,18 @@ def agent_selection():
 
     # Create the selectbox
     selected_agent = st.selectbox(
-        "Agent Name",
+        heading,
         options=[""] + agent_names,
         index=default_index,
-        key="select_learning_agent",
+        key=key,
     )
-
-    # If the selected agent has changed, save the new selection
-    if selected_agent != previously_selected_agent:
-        with open(os.path.join("session.txt"), "w") as f:
-            f.write(selected_agent)
-        try:
-            st.experimental_rerun()
-        except Exception as e:
-            logging.info(e)
+    if key == "select_learning_agent":
+        # If the selected agent has changed, save the new selection
+        if selected_agent != previously_selected_agent:
+            with open(os.path.join("session.txt"), "w") as f:
+                f.write(selected_agent)
+            try:
+                st.experimental_rerun()
+            except Exception as e:
+                logging.info(e)
     return selected_agent

--- a/streamlit/pages/0-Agent_Settings.py
+++ b/streamlit/pages/0-Agent_Settings.py
@@ -44,6 +44,8 @@ extension_setting_keys = get_extension_settings()
 def render_provider_settings(agent_settings, provider_name: str):
     try:
         required_settings = provider_settings(provider_name)
+        # remove "provider" from required settings
+        required_settings.pop("provider")
     except (TypeError, ValueError):
         st.error(
             f"Error loading provider settings: expected a list or a dictionary, but got {required_settings}"
@@ -59,7 +61,9 @@ def render_provider_settings(agent_settings, provider_name: str):
 
     if isinstance(required_settings, dict):
         required_settings = list(required_settings.keys())
-
+    rendered_settings["helper_agent_name"] = agent_selection(
+        key="select_helper_agent", heading="Select Helper Agent"
+    )
     for key in required_settings:
         if key in agent_settings:
             default_value = agent_settings[key]

--- a/streamlit/pages/0-Agent_Settings.py
+++ b/streamlit/pages/0-Agent_Settings.py
@@ -62,7 +62,8 @@ def render_provider_settings(agent_settings, provider_name: str):
     if isinstance(required_settings, dict):
         required_settings = list(required_settings.keys())
     rendered_settings["helper_agent_name"] = agent_selection(
-        key="select_helper_agent", heading="Select Helper Agent"
+        key="select_helper_agent",
+        heading="Select Helper Agent (Your agent will ask this one for help when it needs something.)",
     )
     for key in required_settings:
         if key in agent_settings:


### PR DESCRIPTION
- Improve OpenAI Provider to accept custom endpoints for proxies or other providers using the same schema.
- Added the ability to enter your `API_URI` with the OpenAI provider which will allow that endpoint to be used for other providers that are using OpenAI's package for their endpoints.
- Add Helper Agent. This is a new concept for an agent to assist your agent.  You can choose to make it try to help itself.  Recommend giving your agent access to the `Ask for Help or Further Clarification to Complete Task` command 
- Migrated AGiXT extensions to use SDK.