### PR TITLE
Improved Setup Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ agixt/hub_main.zip
 agixt/*_main.zip
 # docs generation
 _book/
-
+streamlit/
 # 3rd party
 package.json
 package-lock.json

--- a/AGiXT.sh
+++ b/AGiXT.sh
@@ -71,10 +71,6 @@ display_animation() {
     sleep 0.2
   done
 
-
-
-
-
   # Spinning loading indicator
   echo "${BOLD}${GREEN}Loading...${RESET}"
   for i in {1..10}; do
@@ -86,6 +82,67 @@ display_animation() {
   echo
 }
 
+# Check if .env file exists
+environment_setup() {
+    if [[ ! -f ".env" ]]; then
+        clear
+        echo "${BOLD}${CYAN}"
+        echo "    ___   _______ _  ________"
+        echo "   /   | / ____(_) |/ /_  __/"
+        echo "  / /| |/ / __/ /|   / / /   "
+        echo " / ___ / /_/ / //   | / /    "
+        echo "/_/  |_\____/_//_/|_|/_/     "
+        echo "                              "
+        echo "----------------------------------------------------${RESET}"
+        echo "${BOLD}${MAGENTA}Welcome to the AGiXT Environment Setup!${RESET}"
+        read -p "Do you want to set an API key for AGiXT? (Y for yes, N for No): " use_api_key
+        if [[ "$use_api_key" == [Yy]* ]]; then
+            read -p "Enter API key: " api_key
+        fi
+        read -p "Do you have your own AGiXT Hub fork that you would like to install with? (Y for yes, N for No): " hub_repo
+        if [[ "$hub_repo" == [Yy]* ]]; then
+            read -p "Enter your AGiXT Hub fork repo name (e.g. AGiXT/light-hub): " github_repo
+            read -p "Is your AGiXT Hub fork private? It will require credentials if it is not public. (Y for yes, N for No): " is_private
+            if [[ "$is_private" == [Yy]* ]]; then
+                read -p "Enter your GitHub username: " github_username
+                read -p "Enter your GitHub token: " github_token
+            fi
+        fi
+        read -p "Enter the number of AGiXT workers to run with, default is 4: " workers
+        if [[ "$workers" != "" ]]; then
+            if [[ $workers =~ ^[0-9]+$ && $workers -gt 0 ]]; then
+                agixt_workers=$workers
+            else
+                echo "Invalid number of workers, defaulting to 4"
+                agixt_workers=4
+            fi
+        fi
+        read -p "Do you want to use postgres? (Y for yes, N for No and to use file structure instead): " use_db
+        if [[ "$use_db" == [Yy]* ]]; then
+            read -p "Do you want to use an existing postgres database? (Y for yes, N for No and to create a new one automatically): " use_own_db
+            if [[ "$use_own_db" == [Yy]* ]]; then
+                db_connection="true"
+                read -p "Enter postgres host: " postgres_host
+                read -p "Enter postgres port: " postgres_port
+                read -p "Enter postgres database name: " postgres_database
+                read -p "Enter postgres username: " postgres_username
+            fi
+            read -p "Enter postgres password: " postgres_password
+        fi
+        echo "DB_CONNECTED=${db_connection:-false}" >> .env
+        echo "AGIXT_HUB=${github_repo:-AGiXT/light-hub}" >> .env
+        echo "AGIXT_URI=${agixt_uri:-http://agixt:7437}" >> .env
+        echo "AGIXT_API_KEY=${api_key:-}" >> .env
+        echo "UVICORN_WORKERS=${agixt_workers:-4}" >> .env
+        echo "GITHUB_USER=${github_username:-}" >> .env
+        echo "GITHUB_TOKEN=${github_token:-}" >> .env
+        echo "POSTGRES_SERVER=${postgres_host:-db}" >> .env
+        echo "POSTGRES_PORT=${postgres_port:-5432}" >> .env
+        echo "POSTGRES_DB=${postgres_database:-postgres}" >> .env
+        echo "POSTGRES_USER=${postgres_username:-postgres}" >> .env
+        echo "POSTGRES_PASSWORD=${postgres_password:-postgres}" >> .env
+    fi
+}
 # Function to display the menu
 display_menu() {
   clear
@@ -193,9 +250,10 @@ update() {
   git pull
  
     echo "${BOLD}${YELLOW}Step 2: Pulling latest Docker Images...${RESET}"
-  docker compose pull
+  docker-compose pull
 }
 
+environment_setup
 # Main loop to display the menu and handle user input
 while true; do
   display_menu

--- a/agixt/launch-backend.sh
+++ b/agixt/launch-backend.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 
 set -e
+workers="${UVICORN_WORKERS:-4}"
 
 if [ "$DB_CONNECTED" = "true" ]; then
   host="${POSTGRES_SERVER:-db}"
   port="${POSTGRES_PORT:-5432}"
-  db="${POSTGRES_DB:-postgres}"
+  db="${POSTGRES_DB:-postgres}"  
   echo "Waiting for postgres server to start... $host:$port"
   sleep 15
 
@@ -24,4 +25,4 @@ fi
 python3 Hub.py
 echo "Starting AGiXT..."
 sleep 5
-uvicorn app:app --host 0.0.0.0 --port 7437 --workers "$UVICORN_WORKERS" --proxy-headers
+uvicorn app:app --host 0.0.0.0 --port 7437 --workers $workers --proxy-headers

--- a/docs/1-Getting started/Quick Start.md
+++ b/docs/1-Getting started/Quick Start.md
@@ -1,51 +1,51 @@
 ## Quick Start Guide
 
-To get started quickly, you can use the Docker deployment. You will need [docker and docker-compose](https://docs.docker.com/compose/install/) installed on your system. 
+### Prerequisites
+- [Git](https://git-scm.com/downloads)
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+- [Python 3.10](https://www.python.org/downloads/)
 
-Note: If you run locally without docker, it is unsupported.  Any issues you encounter will be closed without comment. Docker is the only way we can say "it works on my machine" and have it mean anything.
-
-### Downloading the docker-compose file
-Open a terminal and run the following commands to download the docker-compose file and the example environment file:
+If using Windows and trying to run locally, it is unsupported, but you will need [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) and [Docker Desktop](https://docs.docker.com/docker-for-windows/install/) at a minimum in addition to the above.
+### Download and Install
+Open a terminal and run the following to download and install AGiXT:
 
 ```
 git clone https://github.com/Josh-XT/AGiXT
 cd AGiXT
+./AGiXT.sh
 ```
 
-### Editing the environment file
-Open the `.env.example` file in a text editor, you will want to at least change the `POSTGRES_PASSWORD` if nothing else.
+### Environment Setup
+During the installation, you will be prompted to enter some settings unless you already have your `.env` file set up.  If you do not have your `.env` file set up, you can use the following as a guide:
 
-- `DB_CONNECTED` is whether or not you want to use a database, this should be `false` by default, change this to `true` if you want to use a database. If you choose to, you will need to edit the database configuration options below, otherwise they can be left alone.
+
 - `AGIXT_API_KEY` is the API key to use for the AGiXT API.  This is empty by default, if you would like to set it, change it in the env file.  The header format for requests will be `Authorization: Bearer {your_api_key}` for any requests to your AGiXT server or you can pass the `api_key` to the AGiXT SDK.
+
 - `AGIXT_HUB` is the name of the AGiXT hub, this should be `AGiXT/hub` if you want to use the [Open Source AGiXT hub.](https://github.com/AGiXT/hub) If you want to use your own fork of AGiXT hub, change this to your username and the name of your fork.
-- `AGIXT_URI` is the URI of the AGiXT hub, this should be `http://agixt:7437` if you are using the docker-compose file as-is. If hosting the AGiXT server separately, change this to the URI of your AGiXT server, otherwise leave it as-is.
+
+- `AGIXT_URI` is the URI of the AGiXT hub, this should be `http://agixt:7437` by default. If hosting the AGiXT server separately, change this to the URI of your AGiXT server, otherwise leave it as-is.
 - `GITHUB_USER` is your GitHub username, this is only required if using your own AGiXT hub to pull your repository data.
 - `GITHUB_TOKEN` is your GitHub personal access token, this is only required if using your own AGiXT hub to pull your repository data.
 - `UVICORN_WORKERS` is the number of workers to run the web server with, this is `6` by default, adjust this to your system's capabilities.
 
 **Database configuration only applicable if using database**
-- `POSTGRES_SERVER` is the name of the database server, this should be `db` if you are using the docker-compose file as-is.
-- `POSTGRES_DB` is the name of the database, this should be `postgres` if you are using the docker-compose file as-is.
-- `POSTGRES_PORT` is the port that the database is listening on, this should be `5432` if you are using the docker-compose file as-is.
-- `POSTGRES_USER` is the username to connect to the database with, this should be `postgres` if you are using the docker-compose file as-is.
+- `DB_CONNECTED` is whether or not you want to use a database, this should be `false` by default, change this to `true` if you want to use a database. If you choose to, you will need to edit the database configuration options below, otherwise they can be left alone.
+- `POSTGRES_SERVER` is the name of the database server, this should be `db` by default.
+- `POSTGRES_DB` is the name of the database, this should be `postgres` by default.
+- `POSTGRES_PORT` is the port that the database is listening on, this should be `5432` by default.
+- `POSTGRES_USER` is the username to connect to the database with, this should be `postgres` by default.
 - `POSTGRES_PASSWORD` **is the password to connect to the database with, this should be changed from the example file if using database.**
 
 
-### Running AGiXT
-Once you have edited the `.env.example` file, save it as `.env` and run the following command to start AGiXT:
+### Running and Updating AGiXT
+Any time you want to run or update AGiXT, run the following commands from your `AGiXT` directory:
 ```
-docker-compose up
+./AGiXT.sh
 ```
 
-Follow the prompts to install the required dependencies.  Any time you want to run AGiXT in the future, just run `docker-compose up` again from the `AGiXT` directory.
+Then follow the prompts to run or update AGiXT either locally or with Docker. We generally recommend running with Docker.
 
 - Access the web interface at http://localhost:8501
 - Access the AGiXT API documentation at http://localhost:7437
 
-### Updating AGiXT
-To update AGiXT, run the following commands from your `AGiXT` directory:
-```
-docker-compose down
-docker-compose pull
-docker-compose up -d
-```

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,10 +24,10 @@ Embracing the spirit of extremity in every facet of life, we introduce AGiXT. Th
     - [Under Development!](#under-development)
   - [Key Features 🗝️](#key-features-️)
   - [Quick Start Guide](#quick-start-guide)
-    - [Downloading the docker-compose file](#downloading-the-docker-compose-file)
-    - [Editing the environment file](#editing-the-environment-file)
-    - [Running AGiXT](#running-agixt)
-    - [Updating AGiXT](#updating-agixt)
+    - [Prerequisites](#prerequisites)
+    - [Download and Install](#download-and-install)
+    - [Environment Setup](#environment-setup)
+    - [Running and Updating AGiXT](#running-and-updating-agixt)
   - [Configuration](#configuration)
   - [Documentation](#documentation)
   - [Contributing](#contributing)
@@ -61,55 +61,54 @@ This project is under active development and may still have issues. We appreciat
 
 ## Quick Start Guide
 
-To get started quickly, you can use the Docker deployment. You will need [docker and docker-compose](https://docs.docker.com/compose/install/) installed on your system. 
+### Prerequisites
+- [Git](https://git-scm.com/downloads)
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+- [Python 3.10](https://www.python.org/downloads/)
 
-Note: If you run locally without docker, it is unsupported.  Any issues you encounter will be closed without comment. Docker is the only way we can say "it works on my machine" and have it mean anything.
-
-### Downloading the docker-compose file
-Open a terminal and run the following commands to download the docker-compose file and the example environment file:
+If using Windows and trying to run locally, it is unsupported, but you will need [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) and [Docker Desktop](https://docs.docker.com/docker-for-windows/install/) at a minimum in addition to the above.
+### Download and Install
+Open a terminal and run the following to download and install AGiXT:
 
 ```
 git clone https://github.com/Josh-XT/AGiXT
 cd AGiXT
+./AGiXT.sh
 ```
 
-### Editing the environment file
-Open the `.env.example` file in a text editor, you will want to at least change the `POSTGRES_PASSWORD` if nothing else.
+### Environment Setup
+During the installation, you will be prompted to enter some settings unless you already have your `.env` file set up.  If you do not have your `.env` file set up, you can use the following as a guide:
 
-- `DB_CONNECTED` is whether or not you want to use a database, this should be `false` by default, change this to `true` if you want to use a database. If you choose to, you will need to edit the database configuration options below, otherwise they can be left alone.
+
 - `AGIXT_API_KEY` is the API key to use for the AGiXT API.  This is empty by default, if you would like to set it, change it in the env file.  The header format for requests will be `Authorization: Bearer {your_api_key}` for any requests to your AGiXT server or you can pass the `api_key` to the AGiXT SDK.
+
 - `AGIXT_HUB` is the name of the AGiXT hub, this should be `AGiXT/hub` if you want to use the [Open Source AGiXT hub.](https://github.com/AGiXT/hub) If you want to use your own fork of AGiXT hub, change this to your username and the name of your fork.
-- `AGIXT_URI` is the URI of the AGiXT hub, this should be `http://agixt:7437` if you are using the docker-compose file as-is. If hosting the AGiXT server separately, change this to the URI of your AGiXT server, otherwise leave it as-is.
+
+- `AGIXT_URI` is the URI of the AGiXT hub, this should be `http://agixt:7437` by default. If hosting the AGiXT server separately, change this to the URI of your AGiXT server, otherwise leave it as-is.
 - `GITHUB_USER` is your GitHub username, this is only required if using your own AGiXT hub to pull your repository data.
 - `GITHUB_TOKEN` is your GitHub personal access token, this is only required if using your own AGiXT hub to pull your repository data.
 - `UVICORN_WORKERS` is the number of workers to run the web server with, this is `6` by default, adjust this to your system's capabilities.
 
 **Database configuration only applicable if using database**
-- `POSTGRES_SERVER` is the name of the database server, this should be `db` if you are using the docker-compose file as-is.
-- `POSTGRES_DB` is the name of the database, this should be `postgres` if you are using the docker-compose file as-is.
-- `POSTGRES_PORT` is the port that the database is listening on, this should be `5432` if you are using the docker-compose file as-is.
-- `POSTGRES_USER` is the username to connect to the database with, this should be `postgres` if you are using the docker-compose file as-is.
+- `DB_CONNECTED` is whether or not you want to use a database, this should be `false` by default, change this to `true` if you want to use a database. If you choose to, you will need to edit the database configuration options below, otherwise they can be left alone.
+- `POSTGRES_SERVER` is the name of the database server, this should be `db` by default.
+- `POSTGRES_DB` is the name of the database, this should be `postgres` by default.
+- `POSTGRES_PORT` is the port that the database is listening on, this should be `5432` by default.
+- `POSTGRES_USER` is the username to connect to the database with, this should be `postgres` by default.
 - `POSTGRES_PASSWORD` **is the password to connect to the database with, this should be changed from the example file if using database.**
 
 
-### Running AGiXT
-Once you have edited the `.env.example` file, save it as `.env` and run the following command to start AGiXT:
+### Running and Updating AGiXT
+Any time you want to run or update AGiXT, run the following commands from your `AGiXT` directory:
 ```
-docker-compose up
+./AGiXT.sh
 ```
 
-Follow the prompts to install the required dependencies.  Any time you want to run AGiXT in the future, just run `docker-compose up` again from the `AGiXT` directory.
+Then follow the prompts to run or update AGiXT either locally or with Docker. We generally recommend running with Docker.
 
 - Access the web interface at http://localhost:8501
 - Access the AGiXT API documentation at http://localhost:7437
-
-### Updating AGiXT
-To update AGiXT, run the following commands from your `AGiXT` directory:
-```
-docker-compose down
-docker-compose pull
-docker-compose up -d
-```
 
 ## Configuration
 


### PR DESCRIPTION
The `AGiXT.sh` script will now guide the user through their environment setup by asking them to answer questions that will build the `.env` file required to run AGiXT.

## Quick Start Guide

### Prerequisites
- [Git](https://git-scm.com/downloads)
- [Docker](https://docs.docker.com/get-docker/)
- [Docker Compose](https://docs.docker.com/compose/install/)
- [Python 3.10](https://www.python.org/downloads/)

If using Windows and trying to run locally, it is unsupported, but you will need [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) and [Docker Desktop](https://docs.docker.com/docker-for-windows/install/) at a minimum in addition to the above.
### Download and Install
Open a terminal and run the following to download and install AGiXT:

```
git clone https://github.com/Josh-XT/AGiXT
cd AGiXT
./AGiXT.sh
```

### Environment Setup
During the installation, you will be prompted to enter some settings unless you already have your `.env` file set up.  If you do not have your `.env` file set up, you can use the following as a guide:


- `AGIXT_API_KEY` is the API key to use for the AGiXT API.  This is empty by default, if you would like to set it, change it in the env file.  The header format for requests will be `Authorization: Bearer {your_api_key}` for any requests to your AGiXT server or you can pass the `api_key` to the AGiXT SDK.

- `AGIXT_HUB` is the name of the AGiXT hub, this should be `AGiXT/hub` if you want to use the [Open Source AGiXT hub.](https://github.com/AGiXT/hub) If you want to use your own fork of AGiXT hub, change this to your username and the name of your fork.

- `AGIXT_URI` is the URI of the AGiXT hub, this should be `http://agixt:7437` by default. If hosting the AGiXT server separately, change this to the URI of your AGiXT server, otherwise leave it as-is.
- `GITHUB_USER` is your GitHub username, this is only required if using your own AGiXT hub to pull your repository data.
- `GITHUB_TOKEN` is your GitHub personal access token, this is only required if using your own AGiXT hub to pull your repository data.
- `UVICORN_WORKERS` is the number of workers to run the web server with, this is `6` by default, adjust this to your system's capabilities.

**Database configuration only applicable if using database**
- `DB_CONNECTED` is whether or not you want to use a database, this should be `false` by default, change this to `true` if you want to use a database. If you choose to, you will need to edit the database configuration options below, otherwise they can be left alone.
- `POSTGRES_SERVER` is the name of the database server, this should be `db` by default.
- `POSTGRES_DB` is the name of the database, this should be `postgres` by default.
- `POSTGRES_PORT` is the port that the database is listening on, this should be `5432` by default.
- `POSTGRES_USER` is the username to connect to the database with, this should be `postgres` by default.
- `POSTGRES_PASSWORD` **is the password to connect to the database with, this should be changed from the example file if using database.**


### Running and Updating AGiXT
Any time you want to run or update AGiXT, run the following commands from your `AGiXT` directory:
```
./AGiXT.sh
```

Then follow the prompts to run or update AGiXT either locally or with Docker. We generally recommend running with Docker.

- Access the web interface at http://localhost:8501
- Access the AGiXT API documentation at http://localhost:7437

