### PR TITLE
add support for Replicate, Cohere, VertexAI, AI21

### DIFF
--- a/agixt/providers/openai.py
+++ b/agixt/providers/openai.py
@@ -3,6 +3,7 @@ import logging
 
 try:
     import openai
+    import litellm 
 except ImportError:
     import sys
     import subprocess
@@ -87,7 +88,7 @@ class OpenaiProvider:
             else:
                 # Use chat completion API
                 messages = [{"role": "system", "content": prompt}]
-                response = openai.ChatCompletion.create(
+                response = litellm.completion(
                     model=self.AI_MODEL,
                     messages=messages,
                     temperature=float(self.AI_TEMPERATURE),


### PR DESCRIPTION
Hi @Josh-XT 

Noticed you're calling several LLM Providers. I'm working on litellm (simple library to standardize LLM API Calls - https://github.com/BerriAI/litellm) and was wondering if we could be helpful.

I added support for Replicate, Cohere, VertexAI, AI21 by replacing the openai endpoint with litellm.completion. The code is pretty similar to the OpenAI class - as litellm follows the same pattern as the openai-python sdk.

Would love to know if this helps.

Happy to add additional tests / update documentation, if the initial PR looks good to you.