### PR TITLE
Test removal of torch and transformers requirements

### DIFF
--- a/agixt/Providers.py
+++ b/agixt/Providers.py
@@ -59,13 +59,6 @@ class Providers:
     def __getattr__(self, attr):
         return getattr(self.instance, attr)
 
-    def get_providers(self):
-        providers = []
-        for provider in glob.glob("providers/*.py"):
-            if "__init__.py" not in provider:
-                providers.append(os.path.splitext(os.path.basename(provider))[0])
-        return providers
-
     def install_requirements(self):
         requirements = getattr(self.instance, "requirements", [])
         installed_packages = {pkg.key: pkg.version for pkg in pkg_resources.working_set}

--- a/agixt/providers/petal.py
+++ b/agixt/providers/petal.py
@@ -49,6 +49,7 @@ class PetalProvider(PipelineProvider):
             HUGGINGFACE_API_KEY,
             **kwargs,
         )
+        self.requirements = ["petals", "transformers[accelerate]", "torch"]
 
     async def instruct(self, prompt, tokens: int = 0):
         self.load_pipeline()

--- a/agixt/providers/pipeline.py
+++ b/agixt/providers/pipeline.py
@@ -36,7 +36,7 @@ class PipelineProvider:
         HUGGINGFACE_API_KEY: str = None,
         **kwargs,
     ):
-        self.requirements = ["transformers", "accelerate"]
+        self.requirements = ["petals", "transformers[accelerate]", "torch"]
         self.MODEL_PATH = MODEL_PATH
         self.AI_TEMPERATURE = AI_TEMPERATURE
         self.MAX_TOKENS = MAX_TOKENS

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,8 +23,6 @@ pillow==9.5.0
 SQLAlchemy==2.0.17
 psycopg2-binary==2.9.6
 openai==0.27.8
-torch==2.0.1
-transformers[accelerate]==4.30.1
 google-api-python-client==2.87.0
 google-auth-oauthlib==1.0.0
 gTTS==2.3.2


### PR DESCRIPTION
Test removal of torch and transformers requirements
- It seems like the only things using them right now are petal provider and pipeline provider. 
- Added requirements to petal and pipeline provider
- Removed ambiguous function in Providers.py