### PR TITLE
Add command execution endpoint

### DIFF
--- a/agixt/app.py
+++ b/agixt/app.py
@@ -1190,5 +1190,27 @@ async def get_extensions():
     return {"extensions": extensions}
 
 
+class CommandExecution(BaseModel):
+    command_name: str
+    command_args: dict
+
+
+@app.post(
+    "/api/agent/{agent_name}/command",
+    tags=["Extensions"],
+    dependencies=[Depends(verify_api_key)],
+)
+async def run_command(agent_name: str, command: CommandExecution):
+    try:
+        agent_config = Agent(agent_name=agent_name).get_agent_config()
+        return {
+            "response": await Extensions(agent_config=agent_config).execute_command(
+                command_name=command.command_name, command_args=command.command_args
+            )
+        }
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=7437)

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -45,5 +45,7 @@ services:
     environment:
       - AGIXT_URI=${AGIXT_URI:-http://agixt:7437}
       - AGIXT_API_KEY=${AGIXT_API_KEY}
+    volumes:
+      - ./WORKSPACE:/app/WORKSPACE
     ports:
       - "8501:8501"

--- a/docker-compose-local-nvidia-sd.yml
+++ b/docker-compose-local-nvidia-sd.yml
@@ -28,6 +28,8 @@ services:
     environment:
       - AGIXT_URI=${AGIXT_URI:-http://agixt:7437}
       - AGIXT_API_KEY=${AGIXT_API_KEY}
+    volumes:
+      - ./WORKSPACE:/app/WORKSPACE
     ports:
       - "8501:8501"
   text-generation-webui:

--- a/docker-compose-local-nvidia.yml
+++ b/docker-compose-local-nvidia.yml
@@ -28,6 +28,8 @@ services:
     environment:
       - AGIXT_URI=${AGIXT_URI:-http://agixt:7437}
       - AGIXT_API_KEY=${AGIXT_API_KEY}
+    volumes:
+      - ./WORKSPACE:/app/WORKSPACE
     ports:
       - "8501:8501"
   text-generation-webui:

--- a/docker-compose-postgres-local-nvidia-sd.yml
+++ b/docker-compose-postgres-local-nvidia-sd.yml
@@ -38,6 +38,8 @@ services:
     environment:
       - AGIXT_URI=${AGIXT_URI:-http://agixt:7437}
       - AGIXT_API_KEY=${AGIXT_API_KEY}
+    volumes:
+      - ./WORKSPACE:/app/WORKSPACE
     ports:
       - "8501:8501"
   text-generation-webui:

--- a/docker-compose-postgres-local-nvidia.yml
+++ b/docker-compose-postgres-local-nvidia.yml
@@ -38,6 +38,8 @@ services:
     environment:
       - AGIXT_URI=${AGIXT_URI:-http://agixt:7437}
       - AGIXT_API_KEY=${AGIXT_API_KEY}
+    volumes:
+      - ./WORKSPACE:/app/WORKSPACE
     ports:
       - "8501:8501"
   text-generation-webui:

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -45,5 +45,7 @@ services:
     environment:
       - AGIXT_URI=${AGIXT_URI:-http://agixt:7437}
       - AGIXT_API_KEY=${AGIXT_API_KEY}
+    volumes:
+      - ./WORKSPACE:/app/WORKSPACE
     ports:
       - "8501:8501"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,5 +28,7 @@ services:
     environment:
       - AGIXT_URI=${AGIXT_URI:-http://agixt:7437}
       - AGIXT_API_KEY=${AGIXT_API_KEY}
+    volumes:
+      - ./WORKSPACE:/app/WORKSPACE
     ports:
       - "8501:8501"


### PR DESCRIPTION
Add command execution endpoint
- This will enable you to execute any AGiXT command through the `/api/agent/{agent_name}/command` endpoint with a post of the `command_name` and `command_args`.  AGiXT SDK updated to v0.0.25 to add an `execute_command` function.

- Add persistence for WORKSPACE folder for Streamlit app.