### PR TITLE
Inject conversation name with command executions

### DIFF
--- a/agixt/Chains.py
+++ b/agixt/Chains.py
@@ -51,6 +51,7 @@ class Chains:
                         agent_name=agent_name,
                         command_name=step["prompt"]["command_name"],
                         command_args=args,
+                        conversation_name=args["conversation_name"],
                     )
                 elif prompt_type == "Prompt":
                     result = ApiClient.prompt_agent(

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -21,6 +21,7 @@ else:
 
 from concurrent.futures import Future
 from Websearch import Websearch
+from Extensions import Extensions
 
 chain = Chain()
 cp = Prompts()
@@ -519,7 +520,9 @@ class Interactions:
                             # Check if the command is a valid command in the self.avent.available_commands list
                             try:
                                 if bool(self.agent.AUTONOMOUS_EXECUTION) == True:
-                                    command_output = await self.agent.execute(
+                                    command_output = await Extensions(
+                                        agent_config=self.agent.AGENT_CONFIG
+                                    ).execute_command(
                                         command_name=command_name,
                                         command_args=command_args,
                                     )
@@ -564,7 +567,7 @@ class Interactions:
                             log_interaction(
                                 agent_name=self.agent_name,
                                 conversation_name=conversation_name,
-                                role="PYTHON-TERMINAL",
+                                role="AGiXT Terminal",
                                 message=message,
                             )
                             logging.info(message)

--- a/agixt/db/Agent.py
+++ b/agixt/db/Agent.py
@@ -256,11 +256,6 @@ class Agent:
                 return config
         return {}
 
-    async def execute(self, command_name, command_args):
-        return await Extensions(agent_config=self.AGENT_CONFIG).execute_command(
-            command_name=command_name, command_args=command_args
-        )
-
     async def instruct(self, prompt, tokens):
         if not prompt:
             return ""

--- a/agixt/fb/Agent.py
+++ b/agixt/fb/Agent.py
@@ -158,11 +158,6 @@ class Agent:
             ).get_available_commands()
             self.clean_agent_config_commands()
 
-    async def execute(self, command_name, command_args):
-        return await Extensions(agent_config=self.AGENT_CONFIG).execute_command(
-            command_name=command_name, command_args=command_args
-        )
-
     async def instruct(self, prompt, tokens):
         if not prompt:
             return ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-agixtsdk==0.0.25
+agixtsdk==0.0.26
 chromadb==0.4.6
 beautifulsoup4==4.12.2
 docker==6.1.2


### PR DESCRIPTION
Inject conversation name with command executions
- This will make any command executions' outputs show up in the selected conversation history.  The default is `AGiXT Terminal Command Execution` and all messages from commands will show up in the history from `AGiXT Terminal`