### PR TITLE
Use memory collection 1 for Websearch storage

### DIFF
--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -85,6 +85,7 @@ class Interactions:
         chain_name="",
         step_number=0,
         conversation_name="",
+        websearch: bool = False,
         **kwargs,
     ):
         if "user_input" in kwargs and user_input == "":
@@ -115,6 +116,13 @@ class Interactions:
                     limit=top_results,
                     min_relevance_score=min_relevance_score,
                 )
+                if websearch:
+                    context += await self.websearch.get_memories(
+                        user_input=user_input,
+                        limit=top_results,
+                        min_relevance_score=min_relevance_score,
+                        collection_number=1,
+                    )
                 if "inject_memories_from_collection_number" in kwargs:
                     if int(kwargs["inject_memories_from_collection_number"]) > 0:
                         context += await WebsiteReader(
@@ -297,6 +305,7 @@ class Interactions:
             chain_name=chain_name,
             step_number=step_number,
             conversation_name=conversation_name,
+            websearch=websearch,
             **kwargs,
         )
         try:

--- a/agixt/Websearch.py
+++ b/agixt/Websearch.py
@@ -52,7 +52,9 @@ class Websearch:
                 soup = BeautifulSoup(content, "html.parser")
                 text_content = soup.get_text()
                 text_content = " ".join(text_content.split())
-                ApiClient.learn_url(agent_name=self.agent_name, url=url)
+                ApiClient.learn_url(
+                    agent_name=self.agent_name, url=url, collection_number=1
+                )
                 self.browsed_links.append(url)
                 return text_content, link_list
         except:


### PR DESCRIPTION
Use memory collection 1 for Websearch storage
- This will keep main context unpolluted and inject from the websearch memory only if websearch is checked.