### PR TITLE
Inject agent name into extensions

### DIFF
--- a/agixt/Extensions.py
+++ b/agixt/Extensions.py
@@ -12,8 +12,11 @@ DISABLED_EXTENSIONS = os.getenv("DISABLED_EXTENSIONS", "").replace(" ", "").spli
 
 
 class Extensions:
-    def __init__(self, agent_config=None, load_commands_flag: bool = True):
+    def __init__(
+        self, agent_name="", agent_config=None, load_commands_flag: bool = True
+    ):
         self.agent_config = agent_config
+        self.agent_name = agent_name if agent_name else "gpt4free"
         if load_commands_flag:
             self.commands = self.load_commands()
         else:

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -527,7 +527,8 @@ class Interactions:
                             try:
                                 if bool(self.agent.AUTONOMOUS_EXECUTION) == True:
                                     command_output = await Extensions(
-                                        agent_config=self.agent.AGENT_CONFIG
+                                        agent_name=self.agent_name,
+                                        agent_config=self.agent.AGENT_CONFIG,
                                     ).execute_command(
                                         command_name=command_name,
                                         command_args=command_args,

--- a/agixt/app.py
+++ b/agixt/app.py
@@ -1238,7 +1238,9 @@ class CommandExecution(BaseModel):
 )
 async def run_command(agent_name: str, command: CommandExecution):
     agent_config = Agent(agent_name=agent_name).get_agent_config()
-    command_output = await Extensions(agent_config=agent_config).execute_command(
+    command_output = await Extensions(
+        agent_name=agent_name, agent_config=agent_config
+    ).execute_command(
         command_name=command.command_name, command_args=command.command_args
     )
     log_interaction(

--- a/agixt/db/Agent.py
+++ b/agixt/db/Agent.py
@@ -207,7 +207,7 @@ class Agent:
         self.AI_PROVIDER = self.AGENT_CONFIG["settings"]["provider"]
         self.PROVIDER = Providers(self.AI_PROVIDER, **self.PROVIDER_SETTINGS)
         self.available_commands = Extensions(
-            agent_config=self.AGENT_CONFIG
+            agent_name=self.agent_name, agent_config=self.AGENT_CONFIG
         ).get_available_commands()
 
     def load_config_keys(self):

--- a/agixt/fb/Agent.py
+++ b/agixt/fb/Agent.py
@@ -154,7 +154,7 @@ class Agent:
                 self.AUTONOMOUS_EXECUTION = True
             self.commands = self.load_commands()
             self.available_commands = Extensions(
-                agent_config=self.AGENT_CONFIG
+                agent_name=self.agent_name, agent_config=self.AGENT_CONFIG
             ).get_available_commands()
             self.clean_agent_config_commands()
 


### PR DESCRIPTION
Inject agent name into extensions
- This will enable all extensions to access the agent's name for reference at `self.agent_name`