### PR TITLE
Add arXiv reader

### DIFF
--- a/agixt/app.py
+++ b/agixt/app.py
@@ -510,6 +510,51 @@ async def learn_arxiv(agent_name: str, arxiv_input: ArxivInput) -> ResponseMessa
     return ResponseMessage(message="Agent learned the content from the arXiv articles.")
 
 
+@app.post(
+    "/api/agent/{agent_name}/reader/{reader_name}",
+    tags=["Memory"],
+    dependencies=[Depends(verify_api_key)],
+)
+async def agent_reader(
+    agent_name: str, reader_name: str, data: dict
+) -> ResponseMessage:
+    agent_config = Agent(agent_name=agent_name).get_agent_config()
+    if reader_name == "file":
+        await FileReader(
+            agent_name=agent_name,
+            agent_config=agent_config,
+            collection_number=data["collection_number"],
+        ).write_file_to_memory(file_path=data["file_path"])
+    elif reader_name == "website":
+        await WebsiteReader(
+            agent_name=agent_name,
+            agent_config=agent_config,
+            collection_number=data["collection_number"],
+        ).write_website_to_memory(url=data["url"])
+    elif reader_name == "github":
+        await GithubReader(
+            agent_name=agent_name,
+            agent_config=agent_config,
+            collection_number=data["collection_number"],
+            use_agent_settings=data["use_agent_settings"],
+        ).write_github_repository_to_memory(
+            github_repo=data["github_repo"],
+            github_user=data["github_user"],
+            github_token=data["github_token"],
+            github_branch=data["github_branch"],
+        )
+    elif reader_name == "arxiv":
+        await ArxivReader(
+            agent_name=agent_name,
+            agent_config=agent_config,
+        ).write_arxiv_articles_to_memory(
+            query=data["query"],
+            article_ids=data["article_ids"],
+            max_articles=data["max_articles"],
+        )
+    return ResponseMessage(message=f"Agent learned the content from the {reader_name}.")
+
+
 @app.delete(
     "/api/agent/{agent_name}/memory",
     tags=["Memory"],

--- a/agixt/readers/arxiv.py
+++ b/agixt/readers/arxiv.py
@@ -1,0 +1,55 @@
+from Memories import Memories
+import os
+import pdfplumber
+import arxiv
+import logging
+
+
+class ArxivReader(Memories):
+    def __init__(
+        self,
+        agent_name: str = "AGiXT",
+        agent_config=None,
+        collection_number: int = 0,
+        **kwargs,
+    ):
+        super().__init__(
+            agent_name=agent_name,
+            agent_config=agent_config,
+            collection_number=collection_number,
+        )
+
+    async def write_arxiv_articles_to_memory(
+        self, query: str = None, article_ids: str = None, max_articles: int = 5
+    ):
+        if query and article_ids:
+            articles = article_ids.split(",") if "," in article_ids else [article_ids]
+            results = arxiv.Search(
+                id_list=articles, query=query, max_results=max_articles
+            )
+        if article_ids and not query:  # Comma separated list of article IDs
+            articles = article_ids.split(",") if "," in article_ids else [article_ids]
+            results = arxiv.Search(id_list=articles)
+        if query and not article_ids:  # Search query
+            results = arxiv.Search(query=query, max_results=max_articles)
+        if results:
+            base_path = os.path.join(os.getcwd(), "WORKSPACE")
+            for result in results:
+                try:
+                    filename = f"{result.get_short_id()}.pdf"
+                    file_path = os.path.join(base_path, filename)
+                    result.download_pdf(dirpath=base_path, filename=filename)
+                    with pdfplumber.open(file_path) as pdf:
+                        content = "\n".join([page.extract_text() for page in pdf.pages])
+                    if content != "":
+                        await self.write_text_to_memory(
+                            user_input=file_path if not query else query,
+                            text=content,
+                            external_source=f"file called {filename} from arXiv",
+                        )
+                    os.remove(file_path)
+                except Exception as e:
+                    logging.error(f"arXiv Reader Error: {e}. Article skipped.")
+            return True
+        else:
+            return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,5 @@ poe-api
 revChatGPT
 hugchat
 GoogleBard
+arxiv
 g4f==0.0.2.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-agixtsdk==0.0.26
+agixtsdk==0.0.27
 chromadb==0.4.6
 beautifulsoup4==4.12.2
 docker==6.1.2


### PR DESCRIPTION
Add arXiv reader
- Not in the Web UI or either SDK yet.
- Reads in any arXiv articles based on search query and/or giving it comma separated a list of article IDs.

Search by search query usage:
```python
ArxivReader.write_arxiv_articles_to_memory(query="Large language model data augmentation", max_articles=5)
```

Search by article IDs usage:
```python
ArxivReader.write_arxiv_articles_to_memory(article_ids="2309.07124,2309.07120")
```