### PR TITLE
Improve file upload

### DIFF
--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -297,8 +297,6 @@ class Interactions:
                 f"{prompt}{user_input}{all_files_content}{context}"
             )
             if tokens_used > int(self.agent.MAX_TOKENS) or files == []:
-                if files != []:
-                    file_list = ", ".join(file_list)
                 fragmented_content = await file_reader.get_memories(
                     user_input=f"{user_input} {file_list}",
                     min_relevance_score=0.3,
@@ -306,7 +304,9 @@ class Interactions:
                 )
                 if fragmented_content != "":
                     the_files = (
-                        f"these files: {file_list}." if file_list != [] else "files:"
+                        f"these files: {', '.join(file_list)}."
+                        if file_list != []
+                        else "files:"
                     )
                     file_contents = f"Here is some potentially relevant information from {the_files}\n{fragmented_content}\n\n"
         skip_args = [

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -288,15 +288,18 @@ class Interactions:
                 f"{prompt}{user_input}{all_files_content}{context}"
             )
             if tokens_used > int(self.agent.MAX_TOKENS) or files == []:
-                file_list = ", ".join(file_list)
+                if files != []:
+                    file_list = ", ".join(file_list)
                 fragmented_content = await file_reader.get_memories(
                     user_input=f"{user_input} {file_list}",
                     min_relevance_score=0.3,
                     limit=top_results if top_results > 0 else 5,
                 )
-                file_contents = "\n".join(fragmented_content)
-                file_contents = f"Here is some relevant information from these files: {file_list}.\n\n{fragmented_content}\n\n"
-
+                if fragmented_content != "":
+                    the_files = (
+                        f"these files: {file_list}." if file_list != [] else "files:"
+                    )
+                    file_contents = f"Here is some potentially relevant information from {the_files}\n{fragmented_content}\n\n"
         skip_args = [
             "user_input",
             "agent_name",

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -145,7 +145,6 @@ class Interactions:
                 context = []
         if "context" in kwargs:
             context += [kwargs["context"]]
-            del kwargs["context"]
         if context != [] and context != "":
             context = "\n".join(context)
             context = f"The user's input causes you remember these things:\n{context}\n"
@@ -260,7 +259,6 @@ class Interactions:
                 files = json.loads(kwargs["import_files"])
             except:
                 files = []
-            del kwargs["import_files"]
             all_files_content = ""
             file_list = []
             for file in files:

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -310,11 +310,12 @@ class Interactions:
             "helper_agent_name",
             "conversation_history",
             "persona",
+            "import_files",
         ]
         args = kwargs.copy()
-        for arg in args:
+        for arg in kwargs:
             if arg in skip_args:
-                del kwargs[arg]
+                del args[arg]
         formatted_prompt = self.custom_format(
             string=prompt,
             user_input=user_input,
@@ -328,7 +329,7 @@ class Interactions:
             conversation_history=conversation_history,
             persona=persona,
             import_files=file_contents,
-            **kwargs,
+            **args,
         )
 
         tokens = get_tokens(formatted_prompt)

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -270,9 +270,7 @@ class Interactions:
                     with open(file_path, "w") as f:
                         f.write(file["file_content"])
                     file_content = file["file_content"]
-
                 else:
-                    # Get the content of the file instead of using the content in the file object
                     with open(file_path, "r") as f:
                         file_content = f.read()
                     file_contents += f"\n`{file_path}` content:\n{file_content}\n\n"

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -283,16 +283,24 @@ class Interactions:
                     await file_reader.write_file_to_memory(
                         file_path=file_path,
                     )
-                    log_interaction(
-                        agent_name=self.agent_name,
-                        conversation_name=conversation_name,
-                        role=self.agent_name,
-                        message=f"I have read the content of the file: `{file_path}`.",
-                    )
                 except:
                     pass
                 if file_name != "" and file_content != "":
                     all_files_content += file_content
+            if files != []:
+                the_files = (
+                    f"these files: {', '.join(file_list)}."
+                    if len(file_list) > 1
+                    else f"the file {file_list[0]}."
+                )
+                log_interaction(
+                    agent_name=self.agent_name,
+                    conversation_name=conversation_name,
+                    role=self.agent_name,
+                    message=f"I have read the file contents of {the_files}.",
+                )
+            else:
+                the_files = "files."
             tokens_used = get_tokens(
                 f"{prompt}{user_input}{all_files_content}{context}"
             )
@@ -303,11 +311,6 @@ class Interactions:
                     limit=top_results if top_results > 0 else 5,
                 )
                 if fragmented_content != "":
-                    the_files = (
-                        f"these files: {', '.join(file_list)}."
-                        if file_list != []
-                        else "files:"
-                    )
                     file_contents = f"Here is some potentially relevant information from {the_files}\n{fragmented_content}\n\n"
         skip_args = [
             "user_input",

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -286,8 +286,9 @@ class Interactions:
                         pass
                 if file_name != "" and file_content != "":
                     all_files_content += file_content
-            content_text = prompt + user_input + all_files_content + context
-            tokens_used = get_tokens(content_text)
+            tokens_used = get_tokens(
+                f"{prompt}{user_input}{all_files_content}{context}"
+            )
             if tokens_used > int(self.agent.MAX_TOKENS) or files == []:
                 file_list = ", ".join(file_list)
                 fragmented_content = await file_reader.get_memories(

--- a/agixt/readers/arxiv.py
+++ b/agixt/readers/arxiv.py
@@ -42,10 +42,11 @@ class ArxivReader(Memories):
                     with pdfplumber.open(file_path) as pdf:
                         content = "\n".join([page.extract_text() for page in pdf.pages])
                     if content != "":
+                        stored_content = f"From arXiv article: {result.title} by {result.authors}\nSummary: {result.summary}\n\nAttached PDF `{filename}` Content:\n{content}"
                         await self.write_text_to_memory(
                             user_input=file_path if not query else query,
-                            text=content,
-                            external_source=f"file called {filename} from arXiv",
+                            text=stored_content,
+                            external_source=f"From arXiv article: {result.title} by {result.authors}",
                         )
                     os.remove(file_path)
                 except Exception as e:

--- a/agixt/readers/file.py
+++ b/agixt/readers/file.py
@@ -83,9 +83,10 @@ class FileReader(Memories):
                     with open(file_path, "r") as f:
                         content = f.read()
             if content != "":
+                stored_content = f"From file: {filename}\n{content}"
                 await self.write_text_to_memory(
                     user_input=file_path,
-                    text=content,
+                    text=stored_content,
                     external_source=f"file called {filename}",
                 )
             return True

--- a/agixt/readers/website.py
+++ b/agixt/readers/website.py
@@ -36,7 +36,9 @@ class WebsiteReader(Memories):
             text_content = soup.get_text()
             text_content = " ".join(text_content.split())
             if text_content:
+                stored_content = f"From website: {url}\n\nContent:\n{text_content}"
                 await self.write_text_to_memory(
-                    user_input=url, text=text_content, external_source=url
+                    user_input=url, text=stored_content, external_source=url
                 )
-            return text_content, link_list
+                return stored_content, link_list
+            return None, None


### PR DESCRIPTION
Improve file upload
- Adding a predefined injection variable called `import_files` to be used in prompts, chains, or 
- If `import_files` is recognized in the prompt, a file uploader will be available on the front end to upload multiple files in the chat.
- Inject memories from collection 4 if `import_files` is in the prompt.
- If the file exists in the working directory, `file_content` can be left empty and will be read in.

```
[
    {
        "file_name.txt": "file_content1",
    },
    {
        "file_name2.txt": "",
    },
]
```