### PR TITLE
Rework command execution format

### DIFF
--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -564,7 +564,7 @@ class Interactions:
                                     command_args=command_args,
                                 )
                         except Exception as e:
-                            command_output = f"Failed to execute command `{command_name}`. Error: {e}. Please try again."
+                            command_output = f"**Failed to execute command `{command_name}` with args `{command_args}`. The command response was: `{e}`. Please try again.**"
                         reformatted_response = reformatted_response.replace(
                             f"#execute_command({command_name}, {command_args})",
                             command_output,

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -545,7 +545,7 @@ class Interactions:
                                 command_args = {}
                         for available_command in self.agent.available_commands:
                             if command_name == available_command["friendly_name"]:
-                                # Check if the command is a valid command in the self.avent.available_commands list
+                                # Check if the command is a valid command in the self.agent.available_commands list
                                 try:
                                     if bool(self.agent.AUTONOMOUS_EXECUTION) == True:
                                         ext = Extensions(

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -227,37 +227,12 @@ class Interactions:
             for arg in command["args"]:
                 verbose_commands += f'        "{arg}": "Your hallucinated input",\n'
             verbose_commands += "    },\n"
-        # Maybe do #command("command_name", command_args) instead of {command_name: {arg1: val1, arg2: val2}}?
-        # To execute a command, use the example below, it will be replaced with the command's output for the user.
-        # #execute_command("command_name", {arg1: val1, arg2: val2})
-        # You can run as many commands as you want, just make sure there is only one command per line.
-
         verbose_commands += "}\n```"
         verbose_commands = """
 **To execute a command, use the example below, it will be replaced with the command's output for the user.**\n
 #execute_command("command_name", {"arg1": "val1", "arg2": "val2"})
 """
 
-        """
-        verbose_commands += "
-**If executing a command, respond in JSON format like the example below.**
-```JSON
-{
-    "response": "Your response to the task.",
-    "commands": {
-        "command_name": {
-            "arg1": "val1",
-            "arg2": "val2"
-        },
-        "command_name2": {
-            "arg1": "val1",
-            "arg2": "val2",
-            "argN": "valN"
-        }
-    }
-}
-        "
-        """
         if prompt_name == "Chat with Commands" and command_list == "":
             prompt_name = "Chat"
         file_contents = ""

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -230,7 +230,7 @@ class Interactions:
         verbose_commands += "}\n```"
         verbose_commands = """
 **To execute a command, use the example below, it will be replaced with the command's output for the user.**\n
-#execute_command("command_name", {"arg1": "val1", "arg2": "val2"})
+#execute_command("Name of Command", {"arg1": "val1", "arg2": "val2"})
 """
 
         if prompt_name == "Chat with Commands" and command_list == "":

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -221,7 +221,7 @@ class Interactions:
         if persona != "":
             persona = f"Your persona is: {persona}\n\n"
 
-        verbose_commands = "**You have commands available to use if they would be useful to complete a user's task.**\n```json\n{\n"
+        verbose_commands = "**You have commands available to use if they would be useful to provide a better user experience.**\n```json\n{\n"
         for command in self.agent.available_commands:
             verbose_commands += f'    "{command["friendly_name"]}": {{\n'
             for arg in command["args"]:
@@ -229,7 +229,7 @@ class Interactions:
             verbose_commands += "    },\n"
         verbose_commands += "}\n```"
         verbose_commands = """
-**To execute a command, use the example below, it will be replaced with the command's output for the user. You can execute command anywhere in the response and they will be executed in the order you use them.**\n
+**To execute a command, use the example below, it will be replaced with the command's output for the user. You can execute a command anywhere in your response and the commands will be executed in the order you use them.**\n
 #execute_command("Name of Command", {"arg1": "val1", "arg2": "val2"})
 """
         if prompt_name == "Chat with Commands" and command_list == "":

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -152,7 +152,6 @@ class Interactions:
             context = f"The user's input causes you remember these things:\n{context}\n"
         else:
             context = ""
-
         command_list = self.agent.get_commands_string()
         if chain_name != "":
             try:
@@ -220,7 +219,6 @@ class Interactions:
                 persona = self.agent.AGENT_CONFIG["settings"]["PERSONA"]
         if persona != "":
             persona = f"Your persona is: {persona}\n\n"
-
         verbose_commands = "**You have commands available to use if they would be useful to provide a better user experience.**\n```json\n{\n"
         for command in self.agent.available_commands:
             verbose_commands += f'    "{command["friendly_name"]}": {{\n'
@@ -329,7 +327,6 @@ class Interactions:
             import_files=file_contents,
             **args,
         )
-
         tokens = get_tokens(formatted_prompt)
         logging.info(f"FORMATTED PROMPT: {formatted_prompt}")
         return formatted_prompt, prompt, tokens
@@ -453,7 +450,6 @@ class Interactions:
                     **kwargs,
                 },
             )
-
         # Handle commands if the prompt contains the {COMMANDS} placeholder
         # We handle command injection that DOESN'T allow command execution by using {command_list} in the prompt
         if "{COMMANDS}" in unformatted_prompt:

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -229,10 +229,9 @@ class Interactions:
             verbose_commands += "    },\n"
         verbose_commands += "}\n```"
         verbose_commands = """
-**To execute a command, use the example below, it will be replaced with the command's output for the user.**\n
+**To execute a command, use the example below, it will be replaced with the command's output for the user. You can execute command anywhere in the response and they will be executed in the order you use them.**\n
 #execute_command("Name of Command", {"arg1": "val1", "arg2": "val2"})
 """
-
         if prompt_name == "Chat with Commands" and command_list == "":
             prompt_name = "Chat"
         file_contents = ""

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -462,11 +462,6 @@ class Interactions:
         if "{COMMANDS}" in unformatted_prompt:
             execution_response = await self.execution_agent(
                 execution_response=self.response,
-                user_input=user_input,
-                context_results=context_results,
-                disable_memory=disable_memory,
-                conversation_name=conversation_name,
-                **kwargs,
             )
             if execution_response != "":
                 self.response = f"{self.response}\n\n{execution_response}"
@@ -538,7 +533,6 @@ class Interactions:
     async def execution_agent(
         self,
         execution_response,
-        **kwargs,
     ):
         commands_to_execute = re.findall(
             r"#execute_command\((.*?)\)", execution_response

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -228,10 +228,7 @@ class Interactions:
                 verbose_commands += f'        "{arg}": "Your hallucinated input",\n'
             verbose_commands += "    },\n"
         verbose_commands += "}\n```"
-        verbose_commands = """
-**To execute a command, use the example below, it will be replaced with the command's output for the user. You can execute a command anywhere in your response and the commands will be executed in the order you use them.**\n
-#execute_command("Name of Command", {"arg1": "val1", "arg2": "val2"})
-"""
+        verbose_commands = '**To execute a command, use the example below, it will be replaced with the commands output for the user. You can execute a command anywhere in your response and the commands will be executed in the order you use them.**\n#execute_command("Name of Command", {"arg1": "val1", "arg2": "val2"})'
         if prompt_name == "Chat with Commands" and command_list == "":
             prompt_name = "Chat"
         file_contents = ""


### PR DESCRIPTION
Rework command execution format
- New format is `#execute_command("Command Name", command_args)` instead of JSON responses being required.  The LLMs can execute commands anywhere in their response and it will be replaced by the output of the command.

```
#execute_command("Command Name", {"arg1: "val1", "arg2": "val2"})
```