### PR TITLE
Use pasted cookie instead of file for Huggingchat

### DIFF
--- a/agixt/providers/huggingchat.py
+++ b/agixt/providers/huggingchat.py
@@ -1,4 +1,5 @@
 import logging
+import json
 
 try:
     from hugchat.hugchat import ChatBot
@@ -13,7 +14,7 @@ except ImportError:
 class HuggingchatProvider:
     def __init__(
         self,
-        HUGGINGCHAT_COOKIE_PATH: str = "./huggingchat-cookies.json",
+        HUGGINGCHAT_COOKIE: str = "",
         MODEL_PATH: str = None,
         AI_MODEL: str = "meta-llama/Llama-2-70b-chat-hf",
         MAX_TOKENS: int = 2048,
@@ -24,7 +25,11 @@ class HuggingchatProvider:
         self.AI_TEMPERATURE = AI_TEMPERATURE
         self.MAX_TOKENS = MAX_TOKENS
         self.AI_MODEL = AI_MODEL
-        self.HUGGINGCHAT_COOKIE_PATH = HUGGINGCHAT_COOKIE_PATH
+        self.HUGGINGCHAT_COOKIE = HUGGINGCHAT_COOKIE
+        try:
+            self.HUGGINGCHAT_COOKIE = json.loads(HUGGINGCHAT_COOKIE)
+        except:
+            self.HUGGINGCHAT_COOKIE = {}
         self.MODELS = {
             "OpenAssistant/oasst-sft-6-llama-30b-xor",
             "meta-llama/Llama-2-70b-chat-hf",
@@ -39,7 +44,7 @@ class HuggingchatProvider:
             logging.info(e)
 
     def load_session(self):
-        self.session = ChatBot(cookie_path=self.HUGGINGCHAT_COOKIE_PATH)
+        self.session = ChatBot(cookies=self.HUGGINGCHAT_COOKIE)
         if self.MODEL_PATH:
             self.session.switch_llm(self.MODELS.index(self.MODEL_PATH))
 

--- a/docs/3-Providers/HuggingChat.md
+++ b/docs/3-Providers/HuggingChat.md
@@ -1,4 +1,5 @@
 # HuggingChat
+
 ## Disclaimer
 
 We are not responsible if Hugging Face bans your account for doing this. This may not be consistent with their rules to use their services in this way. This was developed for experimental purposes and we assume no responsibility for how you use it.
@@ -11,7 +12,4 @@ We are not responsible if Hugging Face bans your account for doing this. This ma
 2. Go to https://huggingface.co/chat
 3. Open the extension
 4. Click the export button (Looks like `[>`), this saves your cookies to clipboard.
-5. Paste your cookies into a file called `huggingchat-cookies.json` in your `AGiXT` directory
-
-### Update your agent settings
-Set `AI_PROVIDER` to `huggingchat`.
+5. Paste your cookies into the `HUGGINGCHAT_COOKIE` field in your agent settings.


### PR DESCRIPTION
Use pasted cookie instead of file for Huggingchat
- You can just paste in your cookie to the `HUGGINGCHAT_COOKIE` field instead of saving a cookie file now.