### PR TITLE
Add audio transcription by boolean

### DIFF
--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -389,8 +389,30 @@ class Interactions:
         browse_links: bool = False,
         prompt_category: str = "Default",
         persist_context_in_history: bool = False,
+        is_m4a_audio: bool = False,
+        is_wav_audio: bool = False,
         **kwargs,
     ):
+        ext = Extensions(
+            agent_name=self.agent_name,
+            agent_config=self.agent.AGENT_CONFIG,
+            conversation_name=conversation_name,
+            ApiClient=self.ApiClient,
+            user=self.user,
+        )
+        # Convert the audio to text
+        if is_m4a_audio:
+            command_output = await ext.execute_command(
+                command_name="Transcribe M4A Audio",
+                command_args={"base64_audio": user_input},
+            )
+            user_input = command_output
+        if is_wav_audio:
+            command_output = await ext.execute_command(
+                command_name="Transcribe WAV Audio",
+                command_args={"base64_audio": user_input},
+            )
+            user_input = command_output
         shots = int(shots)
         if "prompt_category" in kwargs:
             prompt_category = kwargs["prompt_category"]

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -393,23 +393,19 @@ class Interactions:
         is_wav_audio: bool = False,
         **kwargs,
     ):
-        ext = Extensions(
-            agent_name=self.agent_name,
-            agent_config=self.agent.AGENT_CONFIG,
-            conversation_name=conversation_name,
-            ApiClient=self.ApiClient,
-            user=self.user,
-        )
-        # Convert the audio to text
-        if is_m4a_audio:
-            command_output = await ext.execute_command(
-                command_name="Transcribe M4A Audio",
-                command_args={"base64_audio": user_input},
+        if is_m4a_audio or is_wav_audio:
+            # Convert the audio to text
+            ext = Extensions(
+                agent_name=self.agent_name,
+                agent_config=self.agent.AGENT_CONFIG,
+                conversation_name=conversation_name,
+                ApiClient=self.ApiClient,
+                user=self.user,
             )
-            user_input = command_output
-        if is_wav_audio:
             command_output = await ext.execute_command(
-                command_name="Transcribe WAV Audio",
+                command_name="Transcribe M4A Audio"
+                if is_m4a_audio
+                else "Transcribe WAV Audio",
                 command_args={"base64_audio": user_input},
             )
             user_input = command_output


### PR DESCRIPTION
## Add audio transcription by boolean

- Adding `is_m4a_audio` and `is_wav_audio` booleans to the `Interactions`.`run` function. If the `user_input` is passed in as base64 audio, you can set the flag of which type of audio it is and it will automatically transcribe the audio.
- Both new flags are optional and default set to `False`.

### Example of M4A audio transcription in prompt.

```python
# base64_audio = "your base64 encoded audio string from your source."

response = self.ApiClient.prompt_agent(
    agent_name=self.agent_name,
    prompt_name="Chat",
    prompt_args={
        "user_input": base64_audio,
        "is_m4a_audio": True,
        "conversation_name": self.conversation_name,
    },
)
```