### PR TITLE
Add audio transcription to command execution by field

### DIFF
--- a/agixt/Extensions.py
+++ b/agixt/Extensions.py
@@ -147,22 +147,23 @@ class Extensions:
         return commands_list
 
     async def execute_command(self, command_name: str, command_args: dict = None):
-        if "is_m4a_audio" in command_args and "is_wav_audio" in command_args:
-            new_command_args = {}
-            for arg in command_args:
-                if arg == command_args["is_m4a_audio"]:
-                    new_command_args[arg] = self.execute_command(
-                        command_name="Transcribe M4A Audio",
-                        command_args={"base64_audio": command_args[arg]},
-                    )
-                elif arg == command_args["is_wav_audio"]:
-                    new_command_args[arg] = self.execute_command(
-                        command_name="Transcribe WAV Audio",
-                        command_args={"base64_audio": command_args[arg]},
-                    )
-                else:
-                    new_command_args[arg] = command_args[arg]
-            command_args = new_command_args
+        if command_args:
+            if "is_m4a_audio" in command_args or "is_wav_audio" in command_args:
+                new_command_args = {}
+                for arg in command_args:
+                    if arg == command_args["is_m4a_audio"]:
+                        new_command_args[arg] = self.execute_command(
+                            command_name="Transcribe M4A Audio",
+                            command_args={"base64_audio": command_args[arg]},
+                        )
+                    elif arg == command_args["is_wav_audio"]:
+                        new_command_args[arg] = self.execute_command(
+                            command_name="Transcribe WAV Audio",
+                            command_args={"base64_audio": command_args[arg]},
+                        )
+                    else:
+                        new_command_args[arg] = command_args[arg]
+                command_args = new_command_args
         injection_variables = {
             "user": self.user,
             "agent_name": self.agent_name,

--- a/agixt/Extensions.py
+++ b/agixt/Extensions.py
@@ -147,6 +147,22 @@ class Extensions:
         return commands_list
 
     async def execute_command(self, command_name: str, command_args: dict = None):
+        if "is_m4a_audio" in command_args and "is_wav_audio" in command_args:
+            new_command_args = {}
+            for arg in command_args:
+                if arg == command_args["is_m4a_audio"]:
+                    new_command_args[arg] = self.execute_command(
+                        command_name="Transcribe M4A Audio",
+                        command_args={"base64_audio": command_args[arg]},
+                    )
+                elif arg == command_args["is_wav_audio"]:
+                    new_command_args[arg] = self.execute_command(
+                        command_name="Transcribe WAV Audio",
+                        command_args={"base64_audio": command_args[arg]},
+                    )
+                else:
+                    new_command_args[arg] = command_args[arg]
+            command_args = new_command_args
         injection_variables = {
             "user": self.user,
             "agent_name": self.agent_name,

--- a/agixt/extensions/voice_chat.py
+++ b/agixt/extensions/voice_chat.py
@@ -162,6 +162,7 @@ class voice_chat(Extensions):
         )
         # Transcribe the audio to text.
         user_input = await self.transcribe_audio_from_file(filename=filename)
+        user_input.replace("[BLANK_AUDIO]", "")
         os.remove(os.path.join(os.getcwd(), "WORKSPACE", filename))
         return user_input
 

--- a/agixt/extensions/voice_chat.py
+++ b/agixt/extensions/voice_chat.py
@@ -148,6 +148,7 @@ class voice_chat(Extensions):
             f.write(base64.b64decode(base64_audio))
         # Transcribe the audio to text.
         user_input = await self.transcribe_audio_from_file(filename=filename)
+        user_input.replace("[BLANK_AUDIO]", "")
         os.remove(os.path.join(os.getcwd(), "WORKSPACE", filename))
         return user_input
 


### PR DESCRIPTION
## Add audio transcription to command execution by field

The variables `is_m4a_audio` and `is_wav_audio` can be used to target fields in command execution that are populated with base64 audio that needs transcribed to text.

### Example usage

```python
from agixtsdk import AGiXTSDK

sdk = AGiXTSDK( base_uri="http://localhost:7437", api_key="")
base64_audio = get_base64_audio("Today has been a good day!")

response = sdk.execute_command(
    agent_name="gpt4free",
    command_name="Write to File",
    command_args={
        "filename": "notes.txt"
        "text": base64_audio,
        "is_m4a_audio": "text",
    },
    conversation_name="Test Conversation",
)

print(response)
```