### PR TITLE
Add Claude 3 Support

### DIFF
--- a/agixt/providers/claude.py
+++ b/agixt/providers/claude.py
@@ -8,7 +8,7 @@ except ImportError:
     import anthropic
 
 
-# List of models available at https://console.anthropic.com/docs/api/reference
+# List of models available at https://docs.anthropic.com/claude/docs/models-overview
 # Get API key at https://console.anthropic.com/settings/keys
 class ClaudeProvider:
     def __init__(

--- a/agixt/providers/claude.py
+++ b/agixt/providers/claude.py
@@ -9,30 +9,34 @@ except ImportError:
 
 
 # List of models available at https://console.anthropic.com/docs/api/reference
+# Get API key at https://console.anthropic.com/settings/keys
 class ClaudeProvider:
     def __init__(
         self,
         ANTHROPIC_API_KEY: str = "",
-        AI_MODEL: str = "claude-2",
-        MAX_TOKENS: int = 100000,
+        AI_MODEL: str = "claude-3-opus-20240229",
+        MAX_TOKENS: int = 200000,
         AI_TEMPERATURE: float = 0.7,
         **kwargs,
     ):
         self.ANTHROPIC_API_KEY = ANTHROPIC_API_KEY
-        self.MAX_TOKENS = MAX_TOKENS if MAX_TOKENS else 100000
-        self.AI_MODEL = AI_MODEL if AI_MODEL else "claude-2"
+        self.MAX_TOKENS = MAX_TOKENS if MAX_TOKENS else 200000
+        self.AI_MODEL = AI_MODEL if AI_MODEL else "claude-3-opus-20240229"
         self.AI_TEMPERATURE = AI_TEMPERATURE if AI_TEMPERATURE else 0.7
 
     async def inference(self, prompt, tokens: int = 0):
-        max_new_tokens = int(self.MAX_TOKENS) - int(tokens)
         try:
             c = anthropic.Client(api_key=self.ANTHROPIC_API_KEY)
-            return c.completion(
-                prompt=f"{anthropic.HUMAN_PROMPT}{prompt}{anthropic.AI_PROMPT}",
-                stop_sequences=[anthropic.HUMAN_PROMPT],
+            response = c.messages.create(
+                messages=[
+                    {
+                        "role": "user",
+                        "content": prompt,
+                    }
+                ],
                 model=self.AI_MODEL,
-                temperature=float(self.AI_TEMPERATURE),
-                max_tokens_to_sample=max_new_tokens,
+                max_tokens=4096,
             )
+            return response.content[0].text
         except Exception as e:
             return f"Claude Error: {e}"

--- a/docs/3-Providers/Anthropic Claude.md
+++ b/docs/3-Providers/Anthropic Claude.md
@@ -1,11 +1,12 @@
 # Anthropic Claude
+
 - [Anthropic Claude](https://console.anthropic.com/docs/access)
 - [AGiXT](https://github.com/Josh-XT/AGiXT)
 
 ## Quick Start Guide
+
 ### Update your agent settings
+
 1. Set `AI_PROVIDER` to `claude`.
-2. Set `ANTHROPIC_API_KEY` to your OpenAI API key.
-3. Set `AI_MODEL` to `claude-v1-100k` for the 100k model, or `claude-v1` for the regular model.
-4. Set `AI_TEMPERATURE` to a value between 0 and 1. The higher the value, the more creative the output.
-5. Set `MAX_TOKENS` to the maximum number of tokens to generate. 
+2. Set `ANTHROPIC_API_KEY` to your OpenAI API key. Get your Anthroic API key at <https://console.anthropic.com/settings/keys>
+3. Set `AI_MODEL` to `claude-3-opus-20240229`. List of models available at <https://docs.anthropic.com/claude/docs/models-overview> .

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ agixtsdk==0.0.31
 safeexecute==0.0.9
 google-generativeai==0.3.2
 discord==2.3.2
-anthropic==0.16.0
+anthropic==0.18.1
 arxiv==1.4.8
 PyGithub==2.2.0
 hugchat==0.4.0


### PR DESCRIPTION
Add Claude 3 support to Claude provider
- List of Claude models available at https://docs.anthropic.com/claude/docs/models-overview
- Get your Anthropic API key at https://console.anthropic.com/settings/keys