### PR TITLE
Add Get Github Repository Code Contents

### DIFF
--- a/agixt/extensions/github.py
+++ b/agixt/extensions/github.py
@@ -96,6 +96,8 @@ class github(Extensions):
                     or file == "static-requirements.txt"
                 ):
                     other_files.append(os.path.join(root, file))
+        if os.path.exists(os.path.join(os.getcwd(), "WORKSPACE", f"{repo_name}.md")):
+            os.remove(os.path.join(os.getcwd(), "WORKSPACE", f"{repo_name}.md"))
         with open(
             os.path.join(os.getcwd(), "WORKSPACE", f"{repo_name}.md"), "w"
         ) as markdown_file:


### PR DESCRIPTION
Add Get Github Repository Code Contents
- The new command `Get Github Repository Code Contents` will clone the desired repository, then pull the content of all python, powershell, yml into a markdown format. More file types can be added at any point, I put this together for proof of concept to shove the entire AGiXT code base into context for Claude.