### PR TITLE
Add day limit to `get_repo_commits`

### DIFF
--- a/agixt/providers/openai.py
+++ b/agixt/providers/openai.py
@@ -72,7 +72,7 @@ class OpenaiProvider:
                 n=1,
                 stream=False,
             )
-            return response.messages[-1]["content"]
+            return response.choices[0].message.content
         except Exception as e:
             logging.info(f"OpenAI API Error: {e}")
             if "," in self.API_URI:


### PR DESCRIPTION
Add day limit to `get_repo_commits`
- Default limit is 7 days, setting to 0 will automatically paginate and get all commits from the repository but takes some time. It took 45 seconds to pull over a year of commits from this repo.