### PR TITLE
Strip backslash on underscore

### DIFF
--- a/agixt/db/Agent.py
+++ b/agixt/db/Agent.py
@@ -245,7 +245,7 @@ class Agent:
         if not prompt:
             return ""
         answer = await self.PROVIDER.inference(prompt=prompt, tokens=tokens)
-        return answer
+        return answer.replace("\_", "_")
 
     def get_commands_string(self):
         if len(self.available_commands) == 0:

--- a/agixt/fb/Agent.py
+++ b/agixt/fb/Agent.py
@@ -152,7 +152,7 @@ class Agent:
         if not prompt:
             return ""
         answer = await self.PROVIDER.inference(prompt=prompt, tokens=tokens)
-        return answer
+        return answer.replace("\_", "_")
 
     def _load_agent_config_keys(self, keys):
         for key in keys:


### PR DESCRIPTION
Strip backslash on underscore
- Some models are sending backslashes before underscores causing command execution issues with those models.