### PR TITLE
Add agent modes to for additional Chat Completions endpoint functionality

### DIFF
--- a/agixt/Models.py
+++ b/agixt/Models.py
@@ -62,7 +62,7 @@ class Completions(BaseModel):
 
 
 class ChatCompletions(BaseModel):
-    model: str = "gpt-3.5-turbo"
+    model: str = "gpt-3.5-turbo"  # This is the agent name
     messages: List[dict] = None
     temperature: Optional[float] = 0.9
     top_p: Optional[float] = 1.0
@@ -77,7 +77,7 @@ class ChatCompletions(BaseModel):
     presence_penalty: Optional[float] = 0.0
     frequency_penalty: Optional[float] = 0.0
     logit_bias: Optional[Dict[str, float]] = None
-    user: Optional[str] = None
+    user: Optional[str] = "Chat"  # This is the conversation name
 
 
 class TextToSpeech(BaseModel):

--- a/agixt/endpoints/Completions.py
+++ b/agixt/endpoints/Completions.py
@@ -5,10 +5,13 @@ import requests
 import base64
 import PIL
 import uuid
+import json
 from fastapi import APIRouter, Depends, Header
-from Interactions import Interactions, get_tokens
+from Interactions import Interactions, get_tokens, log_interaction
 from Embedding import Embedding
 from ApiClient import Agent, verify_api_key, get_api_client
+from Extensions import Extensions
+from Chains import Chains
 from readers.file import FileReader
 from readers.website import WebsiteReader
 from readers.youtube import YoutubeReader
@@ -92,6 +95,8 @@ async def chat_completion(
     ApiClient = get_api_client(authorization=authorization)
     agent = Interactions(agent_name=prompt.model, user=user, ApiClient=ApiClient)
     agent_config = agent.agent.AGENT_CONFIG
+    conversation_name = prompt.user
+    agent_settings = agent_config["settings"] if "settings" in agent_config else {}
     if "settings" in agent_config:
         if "AI_MODEL" in agent_config["settings"]:
             model = agent_config["settings"]["AI_MODEL"]
@@ -99,114 +104,146 @@ async def chat_completion(
             model = "undefined"
     else:
         model = "undefined"
-    images = []
-    pil_images = []
-    new_prompt = ""
-    conversation_name = "Chat"
-    websearch = False
-    websearch_depth = 0
-    browse_links = True
-    for message in prompt.messages:
-        if "conversation_name" in message:
-            conversation_name = message["conversation_name"]
-        if "context_results" in message:
-            context_results = int(message["context_results"])
-        else:
-            context_results = 5
-        if "prompt_category" in message:
-            prompt_category = message["prompt_category"]
-        else:
-            prompt_category = "Default"
-        if "prompt_name" in message:
-            prompt_name = message["prompt_name"]
+    if "mode" in agent_config:
+        mode = agent_config["mode"]
+    else:
+        mode = "prompt"
+    if (
+        mode == "command"
+        and "command_name" in agent_settings
+        and "command_args" in agent_settings
+        and "command_variable" in agent_settings
+    ):
+        command_args = (
+            json.loads(agent_settings["command_args"])
+            if isinstance(agent_settings["command_args"], str)
+            else agent_settings["command_args"]
+        )
+        command_args[agent_settings["command_variable"]] = prompt.messages[0]["content"]
+        response = await Extensions(
+            agent_name=prompt.model,
+            agent_config=agent_config,
+            conversation_name=conversation_name,
+            ApiClient=ApiClient,
+            api_key=authorization,
+            user=user,
+        ).execute_command(
+            command_name=agent_settings["command_name"],
+            command_args=agent_settings["command_args"],
+        )
+        log_interaction(
+            agent_name=prompt.model,
+            conversation_name=conversation_name,
+            role=prompt.model,
+            message=response,
+            user=user,
+        )
+    elif (
+        mode == "chain"
+        and "chain_name" in agent_settings
+        and "chain_args" in agent_settings
+    ):
+        chain_name = agent_settings["chain_name"]
+        chain_args = (
+            json.loads(agent_settings["chain_args"])
+            if isinstance(agent_settings["chain_args"], str)
+            else agent_settings["chain_args"]
+        )
+        response = Chains(user=user, ApiClient=ApiClient).run_chain(
+            chain_name=chain_name,
+            user_input=prompt.messages[0]["content"],
+            agent_override=prompt.model,
+            all_responses=False,
+            chain_args=chain_args,
+            from_step=1,
+        )
+    else:
+        images = []
+        pil_images = []
+        new_prompt = ""
+        websearch = False
+        websearch_depth = 0
+        browse_links = True
+        if "prompt_name" in agent_settings:
+            prompt_name = agent_settings["prompt_name"]
         else:
             prompt_name = "Chat"
-        if "websearch" in message:
-            websearch = str(message["websearch"]).lower() == "true"
-        if "websearch_depth" in message:
-            websearch_depth = int(message["websearch_depth"])
-        if "browse_links" in message:
-            browse_links = str(message["browse_links"]).lower() == "true"
-        if isinstance(message["content"], str):
-            role = message["role"] if "role" in message else "User"
-            if role.lower() == "system":
-                if "/" in message["content"]:
+        if "prompt_category" in agent_settings:
+            prompt_category = agent_settings["prompt_category"]
+        else:
+            prompt_category = "Default"
+        for message in prompt.messages:
+            if "conversation_name" in message:
+                conversation_name = message["conversation_name"]
+            if "context_results" in message:
+                context_results = int(message["context_results"])
+            else:
+                context_results = 5
+            if "prompt_category" in message:
+                prompt_category = message["prompt_category"]
+            if "prompt_name" in message:
+                prompt_name = message["prompt_name"]
+            if "websearch" in message:
+                websearch = str(message["websearch"]).lower() == "true"
+            if "websearch_depth" in message:
+                websearch_depth = int(message["websearch_depth"])
+            if "browse_links" in message:
+                browse_links = str(message["browse_links"]).lower() == "true"
+            if isinstance(message["content"], str):
+                role = message["role"] if "role" in message else "User"
+                if role.lower() == "system":
+                    if "/" in message["content"]:
+                        new_prompt += f"{message['content']}\n\n"
+                if role.lower() == "user":
                     new_prompt += f"{message['content']}\n\n"
-            if role.lower() == "user":
-                new_prompt += f"{message['content']}\n\n"
-        if isinstance(message["content"], list):
-            for msg in message["content"]:
-                if "text" in msg:
-                    role = message["role"] if "role" in message else "User"
-                    if role.lower() == "user":
-                        new_prompt += f"{msg['text']}\n\n"
-                if "image_url" in msg:
-                    url = (
-                        msg["image_url"]["url"]
-                        if "url" in msg["image_url"]
-                        else msg["image_url"]
-                    )
-                    image_path = f"./WORKSPACE/{uuid.uuid4().hex}.jpg"
-                    if url.startswith("http"):
-                        image = requests.get(url).content
-                    else:
-                        file_type = url.split(",")[0].split("/")[1].split(";")[0]
-                        if file_type == "jpeg":
-                            file_type = "jpg"
-                        image_path = f"./WORKSPACE/{uuid.uuid4().hex}.{file_type}"
-                        image = base64.b64decode(url.split(",")[1])
-                    with open(image_path, "wb") as f:
-                        f.write(image)
-                    images.append(image_path)
-                    pil_img = PIL.Image.open(image_path)
-                    pil_img = pil_img.convert("RGB")
-                    pil_images.append(pil_img)
-                if "audio_url" in message:
-                    audio_url = (
-                        message["audio_url"]["url"]
-                        if "url" in message["audio_url"]
-                        else message["audio_url"]
-                    )
-                    transcribed_audio = AudioToText().transcribe_audio(
-                        file=audio_url, prompt=new_prompt
-                    )
-                    new_prompt += transcribed_audio
-                if "video_url" in message:
-                    video_url = str(
-                        message["video_url"]["url"]
-                        if "url" in message["video_url"]
-                        else message["video_url"]
-                    )
-                    if "collection_number" in message:
-                        collection_number = int(message["collection_number"])
-                    else:
-                        collection_number = 0
-                    if video_url.startswith("https://www.youtube.com/watch?v="):
-                        youtube_reader = YoutubeReader(
-                            agent_name=prompt.model,
-                            agent_config=agent_config,
-                            collection_number=collection_number,
-                            ApiClient=ApiClient,
-                            user=user,
+            if isinstance(message["content"], list):
+                for msg in message["content"]:
+                    if "text" in msg:
+                        role = message["role"] if "role" in message else "User"
+                        if role.lower() == "user":
+                            new_prompt += f"{msg['text']}\n\n"
+                    if "image_url" in msg:
+                        url = (
+                            msg["image_url"]["url"]
+                            if "url" in msg["image_url"]
+                            else msg["image_url"]
                         )
-                        await youtube_reader.write_youtube_captions_to_memory(video_url)
-                if (
-                    "file_url" in message
-                    or "application_url" in message
-                    or "text_url" in message
-                    or "url" in message
-                ):
-                    file_url = str(
-                        message["file_url"]["url"]
-                        if "url" in message["file_url"]
-                        else message["file_url"]
-                    )
-                    if "collection_number" in message:
-                        collection_number = int(message["collection_number"])
-                    else:
-                        collection_number = 0
-                    if file_url.startswith("http"):
-                        if file_url.startswith("https://www.youtube.com/watch?v="):
+                        image_path = f"./WORKSPACE/{uuid.uuid4().hex}.jpg"
+                        if url.startswith("http"):
+                            image = requests.get(url).content
+                        else:
+                            file_type = url.split(",")[0].split("/")[1].split(";")[0]
+                            if file_type == "jpeg":
+                                file_type = "jpg"
+                            image_path = f"./WORKSPACE/{uuid.uuid4().hex}.{file_type}"
+                            image = base64.b64decode(url.split(",")[1])
+                        with open(image_path, "wb") as f:
+                            f.write(image)
+                        images.append(image_path)
+                        pil_img = PIL.Image.open(image_path)
+                        pil_img = pil_img.convert("RGB")
+                        pil_images.append(pil_img)
+                    if "audio_url" in message:
+                        audio_url = (
+                            message["audio_url"]["url"]
+                            if "url" in message["audio_url"]
+                            else message["audio_url"]
+                        )
+                        transcribed_audio = AudioToText().transcribe_audio(
+                            file=audio_url, prompt=new_prompt
+                        )
+                        new_prompt += transcribed_audio
+                    if "video_url" in message:
+                        video_url = str(
+                            message["video_url"]["url"]
+                            if "url" in message["video_url"]
+                            else message["video_url"]
+                        )
+                        if "collection_number" in message:
+                            collection_number = int(message["collection_number"])
+                        else:
+                            collection_number = 0
+                        if video_url.startswith("https://www.youtube.com/watch?v="):
                             youtube_reader = YoutubeReader(
                                 agent_name=prompt.model,
                                 agent_config=agent_config,
@@ -215,70 +252,99 @@ async def chat_completion(
                                 user=user,
                             )
                             await youtube_reader.write_youtube_captions_to_memory(
-                                file_url
+                                video_url
                             )
-                        elif file_url.startswith("https://github.com"):
-                            github_reader = GithubReader(
-                                agent_name=prompt.model,
-                                agent_config=agent_config,
-                                collection_number=collection_number,
-                                ApiClient=ApiClient,
-                                user=user,
-                            )
-                            await github_reader.write_github_repository_to_memory(
-                                github_repo=file_url,
-                                github_user=(
-                                    agent_config["GITHUB_USER"]
-                                    if "GITHUB_USER" in agent_config
-                                    else None
-                                ),
-                                github_token=(
-                                    agent_config["GITHUB_TOKEN"]
-                                    if "GITHUB_TOKEN" in agent_config
-                                    else None
-                                ),
-                                github_branch=(
-                                    "main"
-                                    if "branch" not in message
-                                    else message["branch"]
-                                ),
-                            )
-                        else:
-                            website_reader = WebsiteReader(
-                                agent_name=prompt.model,
-                                agent_config=agent_config,
-                                collection_number=collection_number,
-                                ApiClient=ApiClient,
-                                user=user,
-                            )
-                            await website_reader.write_website_to_memory(url)
-                    else:
-                        file_type = file_url.split(",")[0].split("/")[1].split(";")[0]
-                        file_data = base64.b64decode(file_url.split(",")[1])
-                        file_path = f"./WORKSPACE/{uuid.uuid4().hex}.{file_type}"
-                        with open(file_path, "wb") as f:
-                            f.write(file_data)
-                        file_reader = FileReader(
-                            agent_name=prompt.model,
-                            agent_config=agent_config,
-                            collection_number=collection_number,
-                            ApiClient=ApiClient,
-                            user=user,
+                    if (
+                        "file_url" in message
+                        or "application_url" in message
+                        or "text_url" in message
+                        or "url" in message
+                    ):
+                        file_url = str(
+                            message["file_url"]["url"]
+                            if "url" in message["file_url"]
+                            else message["file_url"]
                         )
-                        await file_reader.write_file_to_memory(file_path)
-    response = await agent.run(
-        user_input=new_prompt,
-        prompt=prompt_name,
-        prompt_category=prompt_category,
-        context_results=context_results,
-        shots=prompt.n,
-        websearch=websearch,
-        websearch_depth=websearch_depth,
-        conversation_name=conversation_name,
-        browse_links=browse_links,
-        images=images,
-    )
-    prompt_tokens = get_tokens(prompt.prompt)
+                        if "collection_number" in message:
+                            collection_number = int(message["collection_number"])
+                        else:
+                            collection_number = 0
+                        if file_url.startswith("http"):
+                            if file_url.startswith("https://www.youtube.com/watch?v="):
+                                youtube_reader = YoutubeReader(
+                                    agent_name=prompt.model,
+                                    agent_config=agent_config,
+                                    collection_number=collection_number,
+                                    ApiClient=ApiClient,
+                                    user=user,
+                                )
+                                await youtube_reader.write_youtube_captions_to_memory(
+                                    file_url
+                                )
+                            elif file_url.startswith("https://github.com"):
+                                github_reader = GithubReader(
+                                    agent_name=prompt.model,
+                                    agent_config=agent_config,
+                                    collection_number=collection_number,
+                                    ApiClient=ApiClient,
+                                    user=user,
+                                )
+                                await github_reader.write_github_repository_to_memory(
+                                    github_repo=file_url,
+                                    github_user=(
+                                        agent_settings["GITHUB_USER"]
+                                        if "GITHUB_USER" in agent_settings
+                                        else None
+                                    ),
+                                    github_token=(
+                                        agent_settings["GITHUB_TOKEN"]
+                                        if "GITHUB_TOKEN" in agent_settings
+                                        else None
+                                    ),
+                                    github_branch=(
+                                        "main"
+                                        if "branch" not in message
+                                        else message["branch"]
+                                    ),
+                                )
+                            else:
+                                website_reader = WebsiteReader(
+                                    agent_name=prompt.model,
+                                    agent_config=agent_config,
+                                    collection_number=collection_number,
+                                    ApiClient=ApiClient,
+                                    user=user,
+                                )
+                                await website_reader.write_website_to_memory(url)
+                        else:
+                            file_type = (
+                                file_url.split(",")[0].split("/")[1].split(";")[0]
+                            )
+                            file_data = base64.b64decode(file_url.split(",")[1])
+                            file_path = f"./WORKSPACE/{uuid.uuid4().hex}.{file_type}"
+                            with open(file_path, "wb") as f:
+                                f.write(file_data)
+                            file_reader = FileReader(
+                                agent_name=prompt.model,
+                                agent_config=agent_config,
+                                collection_number=collection_number,
+                                ApiClient=ApiClient,
+                                user=user,
+                            )
+                            await file_reader.write_file_to_memory(file_path)
+        response = await agent.run(
+            user_input=new_prompt,
+            prompt=prompt_name,
+            prompt_category=prompt_category,
+            context_results=context_results,
+            shots=prompt.n,
+            websearch=websearch,
+            websearch_depth=websearch_depth,
+            conversation_name=conversation_name,
+            browse_links=browse_links,
+            images=images,
+        )
+    prompt_tokens = get_tokens(str(prompt.messages))
     completion_tokens = get_tokens(response)
     total_tokens = int(prompt_tokens) + int(completion_tokens)
     res_model = {
@@ -323,7 +389,7 @@ async def embedding(
     agent_config = Agent(
         agent_name=agent_name, user=user, ApiClient=ApiClient
     ).get_agent_config()
-    agent_settings = agent_config["settings"] if "settings" in agent_config else None
+    agent_settings = agent_config["settings"] if "settings" in agent_config else {}
     tokens = get_tokens(embedding.input)
     embedding = Embedding(agent_settings=agent_settings).embed_text(
         text=embedding.input


### PR DESCRIPTION
Add agent modes to for additional Chat Completions endpoint functionality

## Agent default modes

Changes the behavior of the chat completions endpoint when interacting with the agent to either use a prompt template, command, or chain depending on the agent settings.

- Agent setting `mode` can be `prompt`, `command`, or `chain` in the agent's settings.
- If an agent mode is not defined, the chat completions endpoint will use the `Chat` prompt template.

## `prompt` mode

Executes the designated prompt template when interacted with on the chat completions endpoint.

- Requires `prompt_name` and `prompt_category` to also be defined in the agent settings.
- Will use the `user_input` variable in prompt templates to inject the user's input from their message content.

## `command` mode

Executes the designated command when interacted with on the chat completions endpoint.

- Requires `command_name`, `command_args`, and `command_variable` to be defined in the agent settings.
- `command_variable` is the command to inject the message content into for the command arguments.

## `chain` mode

Executes the designated chain when interacted with on the chat completions endpoint.

- Requires `chain_name`, `chain_args` to be defined in the agent settings.
- Message content will be injected into the `user_input` for running the chain.
