### PR TITLE
Add Stripe CLI Container

### DIFF
--- a/.github/workflows/operation-test-with-jupyter.yml
+++ b/.github/workflows/operation-test-with-jupyter.yml
@@ -64,6 +64,14 @@ on:
         type: string
         default: none
         description: Optional default email available as os.getenv('DEFAULT_EMAIL') in your notebook
+      stripe-secret-key:
+        type: string
+        default: none
+        description: Optional stripe key for running a stripe CLI
+      stripe-webhook-path:
+        type: string
+        default: webhook
+        description: Optional stripe key for running a stripe CLI
     secrets:
       api-key:
         description: Optional api-key available as os.getenv('API_KEY') in your notebook
@@ -82,6 +90,11 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
+      stripe-service:
+        image: stripe/stripe-cli
+        options: --entrypoint "/bin/sh -c 'stripe login --api-key ${{ inputs.stripe-secret-key }} && stripe listen --forward-to service-under-test:${{ inputs.port }}/${{ inputs.stripe-webhook-path }}'"
+        ports:
+          - 5665:5665
       secondary-service:
         image: ${{ inputs.secondary-image }}
         ports:
@@ -131,7 +144,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --fix-missing -y pandoc texlive-xetex texlive-fonts-recommended texlive-plain-generic
-
+      - name: Run Stripe CLI
+        if: inputs.stripe-secret-key
+        run: |
+          docker ps
+          docker exec stripe-service /bin/sh -c "stripe login --api-key $STRIPE_SECRET_KEY && stripe listen --forward-to service-under-test:$PORT/$WEBHOOK_PATH"
       - name: Clone repository and install package
         if: inputs.clone-repo
         run: |

--- a/.github/workflows/operation-test-with-jupyter.yml
+++ b/.github/workflows/operation-test-with-jupyter.yml
@@ -92,7 +92,7 @@ jobs:
           POSTGRES_DB: postgres
       stripe-service:
         image: stripe/stripe-cli
-        options: --entrypoint "/bin/sh" -c "stripe login --api-key ${{ inputs.stripe-secret-key }} && stripe listen --forward-to service-under-test:${{ inputs.port }}/${{ inputs.stripe-webhook-path }} > /stripe-output.txt"        
+        options: --entrypoint "/bin/sh" -c "stripe login --api-key \${{ inputs.stripe-secret-key }} && stripe listen --forward-to service-under-test:\${{ inputs.port }}/\${{ inputs.stripe-webhook-path }} > /stripe-output.txt"        
         ports:
           - 5665:5665
       secondary-service:

--- a/.github/workflows/operation-test-with-jupyter.yml
+++ b/.github/workflows/operation-test-with-jupyter.yml
@@ -144,11 +144,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --fix-missing -y pandoc texlive-xetex texlive-fonts-recommended texlive-plain-generic
-      - name: Run Stripe CLI
-        if: inputs.stripe-secret-key
-        run: |
-          docker ps
-          docker exec stripe-service /bin/sh -c "stripe login --api-key $STRIPE_SECRET_KEY && stripe listen --forward-to service-under-test:$PORT/$WEBHOOK_PATH"
+     
       - name: Clone repository and install package
         if: inputs.clone-repo
         run: |

--- a/.github/workflows/operation-test-with-jupyter.yml
+++ b/.github/workflows/operation-test-with-jupyter.yml
@@ -92,7 +92,7 @@ jobs:
           POSTGRES_DB: postgres
       stripe-service:
         image: stripe/stripe-cli
-        options: --entrypoint "/bin/sh -c 'stripe login --api-key ${{ inputs.stripe-secret-key }} && stripe listen --forward-to service-under-test:${{ inputs.port }}/${{ inputs.stripe-webhook-path }}'"
+        options: --entrypoint "/bin/sh -c 'stripe login --api-key ${{ inputs.stripe-secret-key }} && stripe listen --forward-to service-under-test:${{ inputs.port }}/${{ inputs.stripe-webhook-path }}' > /stripe-output.txt"
         ports:
           - 5665:5665
       secondary-service:
@@ -128,6 +128,7 @@ jobs:
           DEFAULT_EMAIL: ${{ inputs.default-email }}
           DEFAULT_SERVICE: sendgrid
           MFA_VERIFY: authenticator
+          STRIPE_WEBHOOK_SECRET: ${{ env.WEBHOOK_SECRET }}
 
     steps:
       - uses: actions/setup-python@v5
@@ -137,14 +138,16 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 1
-
+      - name: Set stripe webhook secret
+        run: |
+          WEBHOOK_SECRET=$(grep "Your webhook signing secret is" /stripe-output.txt | awk '{print $6}')
+          echo "WEBHOOK_SECRET=$WEBHOOK_SECRET" >> $GITHUB_ENV
       - name: Install jupyter
         run: pip3 install jupyter nbconvert[webpdf]
       - name: Update package lists and install jupyter output generation dependencies
         run: |
           sudo apt-get update
           sudo apt-get install --fix-missing -y pandoc texlive-xetex texlive-fonts-recommended texlive-plain-generic
-     
       - name: Clone repository and install package
         if: inputs.clone-repo
         run: |

--- a/.github/workflows/operation-test-with-jupyter.yml
+++ b/.github/workflows/operation-test-with-jupyter.yml
@@ -92,7 +92,7 @@ jobs:
           POSTGRES_DB: postgres
       stripe-service:
         image: stripe/stripe-cli
-        options: --entrypoint "/bin/sh -c 'stripe login --api-key ${{ inputs.stripe-secret-key }} && stripe listen --forward-to service-under-test:${{ inputs.port }}/${{ inputs.stripe-webhook-path }}' > /stripe-output.txt"
+        options: --entrypoint "/bin/sh" -c "stripe login --api-key ${{ inputs.stripe-secret-key }} && stripe listen --forward-to service-under-test:${{ inputs.port }}/${{ inputs.stripe-webhook-path }} > /stripe-output.txt"        
         ports:
           - 5665:5665
       secondary-service:

--- a/.github/workflows/operation-test-with-jupyter.yml
+++ b/.github/workflows/operation-test-with-jupyter.yml
@@ -92,7 +92,7 @@ jobs:
           POSTGRES_DB: postgres
       stripe-service:
         image: stripe/stripe-cli
-        options: --entrypoint "/bin/sh" -c "stripe login --api-key \${{ inputs.stripe-secret-key }} && stripe listen --forward-to service-under-test:\${{ inputs.port }}/\${{ inputs.stripe-webhook-path }} > /stripe-output.txt"        
+        options: --entrypoint "/bin/sh" -c "stripe login --api-key ${{ inputs.stripe-secret-key }} && stripe listen --forward-to service-under-test:${{ inputs.port }}/${{ inputs.stripe-webhook-path }} > /stripe-output.txt"
         ports:
           - 5665:5665
       secondary-service:


### PR DESCRIPTION
# Description

Create a stripe CLI webhook forwarder to the container under test, to ensure any stripe tests are evaluated correctly. 

## Motivation and Context

Testing a Stripe integration properly requires webhooks to be forwarded. The alternative to doing the CLI forwarding is pointing the Stripe instance to the container which is impractical if not impossible for GitHub Actions.

## How has this been tested?

Tested a deployment on another repository with `uses` but cannot currently get it to resolve correctly. When the `stripe login` command runs, it should return a webhook secret which must then be injected into `service-under-test` as an environment variable to confirm signing.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] My change works!
