### PR TITLE
Update gpt4free Provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN npm install -g playwright && \
     playwright install
 
 # Update g4f
-RUN pip install g4f==0.2.2.8 --force-reinstall
+RUN pip install g4f --force-reinstall
 
 COPY . .
 

--- a/agixt/providers/gpt4free.py
+++ b/agixt/providers/gpt4free.py
@@ -1,54 +1,41 @@
-import logging
-import asyncio
-from g4f.Provider import RetryProvider
-from g4f.models import ModelUtils
+from g4f.client import Client
 
 
 class Gpt4freeProvider:
     def __init__(
         self,
-        AI_MODEL: str = "mixtral-8x7b",
-        MAX_TOKENS: int = 4096,
-        AI_TEMPERATURE: float = 0.7,
-        AI_TOP_P: float = 0.7,
+        AI_MODEL: str = "gpt-4-turbo",
         **kwargs,
     ):
-        self.requirements = ["g4f", "httpx"]
-        self.AI_MODEL = AI_MODEL if AI_MODEL else "mixtral-8x7b"
-        self.AI_TEMPERATURE = AI_TEMPERATURE if AI_TEMPERATURE else 0.7
-        self.MAX_TOKENS = MAX_TOKENS if MAX_TOKENS else 4096
-        self.AI_TOP_P = AI_TOP_P if AI_TOP_P else 0.7
+        self.requirements = ["g4f"]
+        self.AI_MODEL = AI_MODEL if AI_MODEL else "gpt-4-turbo"
 
     @staticmethod
     def services():
         return ["llm"]
 
     async def inference(self, prompt, tokens: int = 0, images: list = []):
-        max_new_tokens = (
-            int(self.MAX_TOKENS) - int(tokens) if tokens > 0 else self.MAX_TOKENS
-        )
-        model = ModelUtils.convert["mixtral-8x7b"]
-        provider = model.best_provider
-        if provider:
-            append_model = f" and model: {model.name}" if model.name else ""
-            logging.info(f"[Gpt4Free] Use provider: {provider.__name__}{append_model}")
+        models = [
+            "gpt-4-turbo",
+            "gpt-4",
+            "mixtral-8x7b",
+            "mistral-7b",
+        ]
+        client = Client()
         try:
-            return (
-                await asyncio.gather(
-                    provider.create_async(
-                        model=model.name,
+            response = client.chat.completions.create(
+                model=self.AI_MODEL,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return response.choices[0].message.content
+        except:
+            for model in models:
+                try:
+                    response = client.chat.completions.create(
+                        model=model,
                         messages=[{"role": "user", "content": prompt}],
-                        max_tokens=max_new_tokens,
-                        temperature=float(self.AI_TEMPERATURE),
-                        top_p=float(self.AI_TOP_P),
                     )
-                )
-            )[0]
-        except Exception as e:
-            raise e
-        finally:
-            if provider and isinstance(provider, RetryProvider):
-                if hasattr(provider, "exceptions"):
-                    for provider_name in provider.exceptions:
-                        error = provider.exceptions[provider_name]
-                        logging.error(f"[Gpt4Free] {provider_name}: {error}")
+                    return response.choices[0].message.content
+                except:
+                    continue
+        return "Unable to retrieve response."


### PR DESCRIPTION
Update g4f Provider
- gpt4free provider hasn't been updated in awhile because of some breaking changes, but has now been updated in this PR. 
- Retry method will now roll over 4 different models if any throw an exception. It will start with the defined `AI_MODEL`, if it fails, it will try `gpt-4-turbo`, then `gpt-4`, then `mixtral-8x7b`, then `mistral-7b`.  So far, I haven't had a generation fail me with this method.