### PR TITLE
Add LOGLEVEL for #1179

### DIFF
--- a/backend.yml
+++ b/backend.yml
@@ -17,6 +17,7 @@ services:
       - DISABLED_PROVIDERS=${DISABLED_PROVIDERS:-}
       - WORKING_DIRECTORY=${WORKING_DIRECTORY:-/agixt/WORKSPACE}
       - TOKENIZERS_PARALLELISM=False
+      - LOGLEVEL=${LOGLEVEL:-ERROR}
       - TZ=${TZ-America/New_York}
     ports:
       - "7437:7437"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -28,6 +28,7 @@ services:
       - DISABLED_PROVIDERS=${DISABLED_PROVIDERS:-}
       - WORKING_DIRECTORY=${WORKING_DIRECTORY:-/agixt/WORKSPACE}
       - TOKENIZERS_PARALLELISM=False
+      - LOGLEVEL=${LOGLEVEL:-INFO}
       - TZ=${TZ-America/New_York}
     ports:
       - "7437:7437"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - AGIXT_URI=${AGIXT_URI-http://agixt:7437}
       - WORKING_DIRECTORY=${WORKING_DIRECTORY:-/agixt/WORKSPACE}
       - TOKENIZERS_PARALLELISM=False
+      - LOGLEVEL=${LOGLEVEL:-ERROR}
       - TZ=${TZ-America/New_York}
     ports:
       - "7437:7437"


### PR DESCRIPTION
Add LOGLEVEL for #1179
- If you want to change the `LOGLEVEL`, you can add it to your `.env` file.

The default on the stable branch is:

```
LOGLEVEL=ERROR
```

The default on the dev branch is:

```
LOGLEVEL=INFO
```

Options are: CRITICAL, ERROR, WARNING, INFO, DEBUG