### PR TITLE
Improve Logic Create Task Chain and fix commands execution prompts

### DIFF
--- a/agixt/extensions/agixt_actions.py
+++ b/agixt/extensions/agixt_actions.py
@@ -300,25 +300,15 @@ class agixt_actions(Extensions):
         new_task_list = []
         current_task = ""
         for task in task_list:
-            if task and task[0] in [
-                str(i) for i in range(10)
-            ]:  # Check for task starting with a digit (0-9)
+            if task and task[0].isdigit():  # Check for task starting with a digit (0-9)
                 if current_task:  # If there's a current task, add it to the list
-                    new_task_list.append(
-                        current_task.lstrip("0123456789.")
-                    )  # Strip leading digits and periods
+                    new_task_list.append(current_task.lstrip("0123456789."))  # Strip leading digits and periods
                 current_task = task  # Start a new current task
             else:
-                current_task += (
-                    "\n" + task
-                )  # If the line doesn't start with a number, it's a subtask - add it to the current task
+                current_task += "\n" + task  # If the line doesn't start with a number, it's a subtask - add it to the current task
 
         if current_task:  # Add the last task if it exists
-            if "\n\n" in current_task:
-                current_task = current_task.split("\n\n")[0]
-            new_task_list.append(
-                current_task.lstrip("0123456789.")
-            )  # Strip leading digits and periods
+            new_task_list.append(current_task.lstrip("0123456789."))  # Strip leading digits and periods
 
         task_list = new_task_list
 

--- a/agixt/prompts/Default/Execution.txt
+++ b/agixt/prompts/Default/Execution.txt
@@ -1,4 +1,5 @@
 {context}
+{COMMANDS}
 
 You are an AI who performs one task based on the following objective: {objective}.
 Your role is to do anything asked of you with precision. You have the following constraints:
@@ -9,25 +10,3 @@ Your role is to do anything asked of you with precision. You have the following 
 Take into account these previously completed tasks from context.
 
 Your task: {user_input}
-
-{COMMANDS}
-
-RESPOND IN THE FOLLOWING JSON FORMAT ONLY! If there are no commands, simply make the commands section an empty object like {}.
-```JSON
-{
-    "response": "Your response to the task.",
-    "commands": {
-        "command_name": {
-            "arg1": "val1",
-            "arg2": "val2"
-        },
-        "command_name2": {
-            "arg1": "val1",
-            "arg2": "val2",
-            "argN": "valN"
-        }
-    }
-}
-```
-
-Response: 

--- a/agixt/prompts/Default/SmartInstruct-Execution.txt
+++ b/agixt/prompts/Default/SmartInstruct-Execution.txt
@@ -13,21 +13,3 @@ Task Response:
 You are a command execution agent.  
 1. If there are no commands, respond only with empty Json like {}. 
 2. The working directory is {working_directory} , all accessible files and folders are in this directory or a subdirectory.
-3. If there are commands to use from the Task Response, format them as follows in your response:
-
-
-```
-{
-    "commands": {
-        "command_name": {
-            "arg1": "val1",
-            "arg2": "val2"
-        },
-        "command_name2": {
-            "arg1": "val1",
-            "arg2": "val2",
-            "argN": "valN"
-        }
-    }
-}
-```

--- a/agixt/prompts/Default/SmartTask-Execution.txt
+++ b/agixt/prompts/Default/SmartTask-Execution.txt
@@ -11,21 +11,3 @@ Task Response:
 ```
 {previous_response}
 ```
-
-You are a command execution agent.  If there are no commands, respond only with empty Json like {}. If there are commands to use from the Task Response, format them as follows in your response:
-
-```
-{
-    "commands": {
-        "command_name": {
-            "arg1": "val1",
-            "arg2": "val2"
-        },
-        "command_name2": {
-            "arg1": "val1",
-            "arg2": "val2",
-            "argN": "valN"
-        }
-    }
-}
-```

--- a/agixt/prompts/Default/Task Execution.txt
+++ b/agixt/prompts/Default/Task Execution.txt
@@ -8,21 +8,3 @@ You have the following constraints:
 3. Use any available context to help make decisions.
 4. Only use available commands.
 5. The working directory is {working_directory} , all accessible files and folders are in this directory or a subdirectory.
-
-RESPOND IN THE FOLLOWING JSON FORMAT ONLY! If there are no commands, simply make the commands section an empty object like {}.
-```JSON
-{
-    "response": "Your response to the task.",
-    "commands": {
-        "command_name": {
-            "arg1": "val1",
-            "arg2": "val2"
-        },
-        "command_name2": {
-            "arg1": "val1",
-            "arg2": "val2",
-            "argN": "valN"
-        }
-    }
-}
-```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] My change works!


The main changes are:

Checking if the task starts with a digit using task[0].isdigit() instead of task[0] in [str(i) for i in range(10)].
Appending the current_task to the new_task_list after the loop ends (instead of inside the loop) to handle the last task correctly.
Removing the check for double newlines ("\n\n") in the current_task as it's not necessary.

The updated function should work correctly to create a task chain from a numbered list of tasks, splitting subtasks properly and handling the last task correctly.
