### PR TITLE
Rework websearch to rotate endpoints on failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN pip install spacy && \
 # Install Playwright
 RUN npm install -g playwright && \
     npx playwright install && \
-    playwright install --with-deps
+    playwright install
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,8 @@ RUN pip install -r requirements.txt
 
 # Download spaCy language model
 RUN pip install spacy && \
-    python -m spacy download en_core_web_sm
+    python -m spacy download en_core_web_sm && \
+    pip install textacy==0.13.0
 
 # Install Playwright
 RUN npm install -g playwright && \

--- a/agixt/Agent.py
+++ b/agixt/Agent.py
@@ -389,6 +389,7 @@ class Agent:
                         self.session.add(agent_command)
         else:
             for setting_name, setting_value in new_config.items():
+                logging.info(f"Setting {setting_name} to {setting_value}.")
                 agent_setting = (
                     self.session.query(AgentSettingModel)
                     .filter_by(agent_id=agent.id, name=setting_name)

--- a/agixt/Extensions.py
+++ b/agixt/Extensions.py
@@ -107,8 +107,6 @@ class Extensions:
                                 params,
                             )
                         )
-        # Return the commands list
-        logging.debug(f"loaded commands: {commands}")
         return commands
 
     def get_extension_settings(self):

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -465,22 +465,9 @@ class Interactions:
                     role=self.agent_name,
                     message=f"[ACTIVITY] Searching the web...",
                 )
-                search_string = await self.run(
-                    user_input=user_input,
-                    prompt_name="WebSearch",
-                    context_results=context_results if context_results > 0 else 5,
-                    log_user_input=False,
-                    browse_links=False,
-                    websearch=False,
-                )
-                c.log_interaction(
-                    role=self.agent_name,
-                    message=f"[ACTIVITY] Searching web for: {search_string}",
-                )
                 # try:
                 await self.websearch.websearch_agent(
                     user_input=user_input,
-                    search_string=search_string,
                     websearch_depth=websearch_depth,
                     websearch_timeout=websearch_timeout,
                 )

--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -451,7 +451,7 @@ class Interactions:
             await self.websearch.scrape_websites(
                 user_input=user_input,
                 search_depth=websearch_depth,
-                summarize_content=True,
+                summarize_content=False,
                 conversation_name=conversation_name,
             )
         if websearch:

--- a/agixt/Memories.py
+++ b/agixt/Memories.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from collections import Counter
 from typing import List
 from Globals import getenv, DEFAULT_USER
+from textacy.extract.keyterms import textrank
 
 logging.basicConfig(
     level=getenv("LOG_LEVEL"),
@@ -32,6 +33,12 @@ def nlp(text):
         sp = spacy.load("en_core_web_sm")
     sp.max_length = 99999999999999999999999
     return sp(text)
+
+
+def extract_keywords(doc=None, text="", limit=10):
+    if not doc:
+        doc = nlp(text)
+    return [k for k, s in textrank(doc, topn=limit)]
 
 
 def snake(old_str: str = ""):
@@ -488,9 +495,7 @@ class Memories:
         content_chunks = []
         chunk = []
         chunk_len = 0
-        keywords = [
-            token.text for token in doc if token.pos_ in {"NOUN", "PROPN", "VERB"}
-        ]
+        keywords = set(extract_keywords(doc=doc, limit=10))
         for sentence in sentences:
             sentence_tokens = len(sentence)
             if chunk_len + sentence_tokens > chunk_size and chunk:

--- a/agixt/Websearch.py
+++ b/agixt/Websearch.py
@@ -96,7 +96,7 @@ class Websearch:
         if get_tokens(text=content) < int(max_tokens):
             return self.ApiClient.prompt_agent(
                 agent_name=self.agent_name,
-                prompt_name="Website Summary",
+                prompt_name="Web Summary",
                 prompt_args={
                     "user_input": content,
                     "url": url,
@@ -114,7 +114,7 @@ class Websearch:
             new_content.append(
                 self.ApiClient.prompt_agent(
                     agent_name=self.agent_name,
-                    prompt_name="Website Summary",
+                    prompt_name="Web Summary",
                     prompt_args={
                         "user_input": chunk,
                         "url": url,

--- a/agixt/Websearch.py
+++ b/agixt/Websearch.py
@@ -464,7 +464,6 @@ class Websearch:
             endpoint = endpoint[:-1]
         if endpoint.endswith("search"):
             endpoint = endpoint[:-6]
-        query = urllib.parse.quote(query)
         logging.info(f"Websearching for {query} on {endpoint}")
         text_content, link_list = await self.get_web_content(
             url=f"{endpoint}/search?q={query}"
@@ -507,6 +506,7 @@ class Websearch:
                     },
                 )
                 links = []
+                search_string = urllib.parse.quote(search_string)
                 content, links = await self.web_search(query=search_string)
                 logging.info(f"Found {len(links)} results for {search_string}")
                 if len(links) > websearch_depth:

--- a/agixt/Websearch.py
+++ b/agixt/Websearch.py
@@ -466,6 +466,8 @@ class Websearch:
         text_content, link_list = await self.get_web_content(
             url=f"{endpoint}/search?q={query}"
         )
+        if link_list is None:
+            link_list = []
         if len(link_list) < 5:
             self.failures.append(endpoint)
             await self.update_search_provider()

--- a/agixt/Websearch.py
+++ b/agixt/Websearch.py
@@ -14,14 +14,8 @@ from ApiClient import Agent, Conversations
 from Globals import getenv, get_tokens
 from readers.youtube import YoutubeReader
 from readers.github import GithubReader
-from pydantic import BaseModel
 from datetime import datetime
 from Memories import extract_keywords
-
-
-class SearchResponse(BaseModel):
-    href: str
-    summary: str
 
 
 logging.basicConfig(
@@ -499,9 +493,6 @@ class Websearch:
         )
         if link_list is None:
             link_list = []
-        logging.info(f"Found {len(link_list)} results for {query}")
-        logging.info(f"Content: {text_content}")
-        logging.info(f"Links: {link_list}")
         if len(link_list) < 5:
             self.failures.append(self.websearch_endpoint)
             await self.update_search_provider()
@@ -543,7 +534,9 @@ class Websearch:
                 if links == [] or links is None:
                     links = []
                     content, links = await self.web_search(query=search_string)
-                logging.info(f"Found {len(links)} results for {search_string}")
+                logging.info(
+                    f"Found {len(links)} results for {search_string} using DDG."
+                )
                 if len(links) > websearch_depth:
                     links = links[:websearch_depth]
                 if links is not None and len(links) > 0:

--- a/agixt/Websearch.py
+++ b/agixt/Websearch.py
@@ -558,7 +558,7 @@ class Websearch:
         except:
             websearch_timeout = 0
         if websearch_depth > 0:
-            if len(search_string) > 0:
+            if len(user_input) > 0:
                 search_string = self.ApiClient.prompt_agent(
                     agent_name=self.agent_name,
                     prompt_name="WebSearch",

--- a/agixt/Websearch.py
+++ b/agixt/Websearch.py
@@ -393,22 +393,6 @@ class Websearch:
         self.websearch_endpoint = websearch_endpoint
         return websearch_endpoint
 
-    async def web_search(self, query: str) -> List[str]:
-        endpoint = self.agent_settings["websearch_endpoint"]
-        if endpoint.endswith("/"):
-            endpoint = endpoint[:-1]
-        if endpoint.endswith("search"):
-            endpoint = endpoint[:-6]
-        query = urllib.parse.quote(query)
-        text_content, link_list = await self.get_web_content(
-            url=f"{endpoint}/search?q={query}"
-        )
-        if len(link_list) < 5:
-            self.failures.append(endpoint)
-            await self.update_search_provider()
-            return await self.web_search(query=query)
-        return link_list
-
     async def scrape_websites(
         self,
         user_input: str = "",
@@ -471,6 +455,22 @@ class Websearch:
                 message=f"[ACTIVITY] {message}",
             )
         return message
+
+    async def web_search(self, query: str) -> List[str]:
+        endpoint = self.websearch_endpoint
+        if endpoint.endswith("/"):
+            endpoint = endpoint[:-1]
+        if endpoint.endswith("search"):
+            endpoint = endpoint[:-6]
+        query = urllib.parse.quote(query)
+        text_content, link_list = await self.get_web_content(
+            url=f"{endpoint}/search?q={query}"
+        )
+        if len(link_list) < 5:
+            self.failures.append(endpoint)
+            await self.update_search_provider()
+            return await self.web_search(query=query)
+        return link_list
 
     async def websearch_agent(
         self,

--- a/agixt/Websearch.py
+++ b/agixt/Websearch.py
@@ -431,18 +431,18 @@ class Websearch:
         servers.append("https://lite.duckduckgo.com/lite")
         websearch_endpoint = self.websearch_endpoint
         if "websearch_endpoint" not in self.agent_settings:
-            self.ApiClient.update_agent_settings(
-                agent_name=self.agent_name,
-                settings={"websearch_endpoint": websearch_endpoint},
+            self.agent.update_agent_config(
+                new_config={"websearch_endpoint": websearch_endpoint},
+                config_key="settings",
             )
             return websearch_endpoint
         if (
             self.agent_settings["websearch_endpoint"] == ""
             or self.agent_settings["websearch_endpoint"] is None
         ):
-            self.ApiClient.update_agent_settings(
-                agent_name=self.agent_name,
-                settings={"websearch_endpoint": websearch_endpoint},
+            self.agent.update_agent_config(
+                new_config={"websearch_endpoint": websearch_endpoint},
+                config_key="settings",
             )
             return websearch_endpoint
         random_index = random.randint(0, len(servers) - 1)
@@ -451,9 +451,9 @@ class Websearch:
             random_index = random.randint(0, len(servers) - 1)
             websearch_endpoint = servers[random_index]
         self.agent_settings["websearch_endpoint"] = websearch_endpoint
-        self.ApiClient.update_agent_settings(
-            agent_name=self.agent_name,
-            settings={"websearch_endpoint": websearch_endpoint},
+        self.agent.update_agent_config(
+            new_config={"websearch_endpoint": websearch_endpoint},
+            config_key="settings",
         )
         self.websearch_endpoint = websearch_endpoint
         return websearch_endpoint

--- a/agixt/Websearch.py
+++ b/agixt/Websearch.py
@@ -16,6 +16,7 @@ from readers.youtube import YoutubeReader
 from readers.github import GithubReader
 from pydantic import BaseModel
 from datetime import datetime
+from Memories import extract_keywords
 
 
 class SearchResponse(BaseModel):
@@ -507,6 +508,11 @@ class Websearch:
                         "websearch": "false",
                     },
                 )
+                keywords = extract_keywords(text=user_input, limit=5)
+                if keywords:
+                    search_string = " ".join(keywords)
+                    # add month and year to the end of the search string
+                    search_string += f" {datetime.now().strftime('%B %Y')}"
                 links = []
                 content, links = await self.web_search(query=search_string)
                 logging.info(f"Found {len(links)} results for {search_string}")

--- a/agixt/Websearch.py
+++ b/agixt/Websearch.py
@@ -431,6 +431,7 @@ class Websearch:
         servers.append("https://lite.duckduckgo.com/lite")
         websearch_endpoint = self.websearch_endpoint
         if "websearch_endpoint" not in self.agent_settings:
+            self.agent_settings["websearch_endpoint"] = websearch_endpoint
             self.agent.update_agent_config(
                 new_config={"websearch_endpoint": websearch_endpoint},
                 config_key="settings",
@@ -440,6 +441,7 @@ class Websearch:
             self.agent_settings["websearch_endpoint"] == ""
             or self.agent_settings["websearch_endpoint"] is None
         ):
+            self.agent_settings["websearch_endpoint"] = websearch_endpoint
             self.agent.update_agent_config(
                 new_config={"websearch_endpoint": websearch_endpoint},
                 config_key="settings",
@@ -506,7 +508,6 @@ class Websearch:
                     },
                 )
                 links = []
-                search_string = urllib.parse.quote(search_string)
                 content, links = await self.web_search(query=search_string)
                 logging.info(f"Found {len(links)} results for {search_string}")
                 if len(links) > websearch_depth:

--- a/agixt/Websearch.py
+++ b/agixt/Websearch.py
@@ -431,7 +431,7 @@ class Websearch:
         return websearch_endpoint
 
     async def web_search(self, query: str) -> List[str]:
-        driver = uc.Chrome(headless=True)
+        driver = uc.Chrome(headless=True, use_subprocess=False)
         query = urllib.parse.quote(query)
         endpoint = self.agent_settings["websearch_endpoint"]
         if endpoint.endswith("/"):

--- a/agixt/Websearch.py
+++ b/agixt/Websearch.py
@@ -469,12 +469,11 @@ class Websearch:
         text_content, link_list = await self.get_web_content(
             url=f"{endpoint}/search?q={query}"
         )
+        if link_list is None:
+            link_list = []
         logging.info(f"Found {len(link_list)} results for {query}")
         logging.info(f"Content: {text_content}")
         logging.info(f"Links: {link_list}")
-
-        if link_list is None:
-            link_list = []
         if len(link_list) < 5:
             self.failures.append(self.websearch_endpoint)
             await self.update_search_provider()

--- a/agixt/Websearch.py
+++ b/agixt/Websearch.py
@@ -539,7 +539,7 @@ class Websearch:
                     search_string = " ".join(keywords)
                     # add month and year to the end of the search string
                     search_string += f" {datetime.now().strftime('%B %Y')}"
-                links = self.ddg_search(query=search_string)
+                links = await self.ddg_search(query=search_string)
                 if links == [] or links is None:
                     links = []
                     content, links = await self.web_search(query=search_string)

--- a/agixt/Websearch.py
+++ b/agixt/Websearch.py
@@ -465,9 +465,14 @@ class Websearch:
         if endpoint.endswith("search"):
             endpoint = endpoint[:-6]
         query = urllib.parse.quote(query)
+        logging.info(f"Websearching for {query} on {endpoint}")
         text_content, link_list = await self.get_web_content(
             url=f"{endpoint}/search?q={query}"
         )
+        logging.info(f"Found {len(link_list)} results for {query}")
+        logging.info(f"Content: {text_content}")
+        logging.info(f"Links: {link_list}")
+
         if link_list is None:
             link_list = []
         if len(link_list) < 5:

--- a/agixt/Websearch.py
+++ b/agixt/Websearch.py
@@ -521,6 +521,7 @@ class Websearch:
             websearch_timeout = 0
         if websearch_depth > 0:
             if len(search_string) > 0:
+                search_string = str(search_string)
                 links = []
                 if self.searx_instance_url != "":
                     links = await self.search(query=search_string)

--- a/agixt/XT.py
+++ b/agixt/XT.py
@@ -526,7 +526,7 @@ class AGiXT:
         self,
         urls: list = [],
         scrape_depth: int = 3,
-        summarize_content: bool = True,
+        summarize_content: bool = False,
         conversation_name: str = "",
     ):
         """
@@ -847,7 +847,7 @@ class AGiXT:
             await self.learn_from_websites(
                 urls=urls,
                 scrape_depth=3,
-                summarize_content=True,
+                summarize_content=False,
                 conversation_name=conversation_name,
             )
             if mode == "command" and command_name and command_variable:

--- a/agixt/XT.py
+++ b/agixt/XT.py
@@ -6,7 +6,9 @@ from pydub import AudioSegment
 from Globals import getenv, get_tokens, DEFAULT_SETTINGS
 from Models import ChatCompletions
 from datetime import datetime
-from typing import List
+from typing import Type, get_args, get_origin, Union, List
+from enum import Enum
+from pydantic import BaseModel
 import logging
 import asyncio
 import os
@@ -1063,3 +1065,65 @@ class AGiXT:
             new_config=self.agent_settings, config_key="settings"
         )
         return dpo_dataset
+
+    def convert_to_pydantic_model(
+        self,
+        input_string: str,
+        model: Type[BaseModel],
+        max_failures: int = 3,
+        response_type: str = None,
+        **kwargs,
+    ):
+        input_string = str(input_string)
+        fields = model.__annotations__
+        field_descriptions = []
+        for field, field_type in fields.items():
+            description = f"{field}: {field_type}"
+            if get_origin(field_type) == Union:
+                field_type = get_args(field_type)[0]
+            if isinstance(field_type, type) and issubclass(field_type, Enum):
+                enum_values = ", ".join([f"{e.name} = {e.value}" for e in field_type])
+                description += f" (Enum values: {enum_values})"
+            field_descriptions.append(description)
+        schema = "\n".join(field_descriptions)
+        response = self.inference(
+            user_input=input_string,
+            schema=schema,
+            prompt_category="Default",
+            prompt_name="Convert to Pydantic Model",
+            log_user_input=False,
+        )
+        if "```json" in response:
+            response = response.split("```json")[1].split("```")[0].strip()
+        elif "```" in response:
+            response = response.split("```")[1].strip()
+        try:
+            response = json.loads(response)
+            if response_type == "json":
+                return response
+            else:
+                return model(**response)
+        except Exception as e:
+            if "failures" in kwargs:
+                failures = int(kwargs["failures"]) + 1
+                if failures > max_failures:
+                    logging.error(
+                        f"Error: {e} . Failed to convert the response to the model after 3 attempts. Response: {response}"
+                    )
+                    return (
+                        response
+                        if response
+                        else "Failed to convert the response to the model."
+                    )
+            else:
+                failures = 1
+            logging.warning(
+                f"Error: {e} . Failed to convert the response to the model, trying again. {failures}/3 failures. Response: {response}"
+            )
+            return self.convert_to_pydantic_model(
+                input_string=input_string,
+                model=model,
+                max_failures=max_failures,
+                response_type=response_type,
+                failures=failures,
+            )

--- a/agixt/endpoints/Agent.py
+++ b/agixt/endpoints/Agent.py
@@ -192,8 +192,17 @@ async def prompt_agent(
 ):
     ApiClient = get_api_client(authorization=authorization)
     agent = Interactions(agent_name=agent_name, user=user, ApiClient=ApiClient)
+    if (
+        "prompt" in agent_prompt.prompt_args
+        and "prompt_name" not in agent_prompt.prompt_args
+    ):
+        agent_prompt.prompt_args["prompt_name"] = agent_prompt.prompt_args["prompt"]
+    if "prompt_name" not in agent_prompt.prompt_args:
+        agent_prompt.prompt_args["prompt_name"] = "Chat"
+    if "prompt_category" not in agent_prompt.prompt_args:
+        agent_prompt.prompt_args["prompt_category"] = "Default"
+    agent_prompt.prompt_args = {k: v for k, v in agent_prompt.prompt_args.items()}
     response = await agent.run(
-        prompt=agent_prompt.prompt_name,
         log_user_input=True,
         **agent_prompt.prompt_args,
     )

--- a/agixt/prompts/Default/Convert to Pydantic Model.txt
+++ b/agixt/prompts/Default/Convert to Pydantic Model.txt
@@ -1,0 +1,11 @@
+Act as a JSON converter that converts any text into the desired JSON format based on the schema provided. Respond only with JSON in a properly formatted markdown code block, no explanations. Make your best assumptions based on data to try to fill in information to match the schema provided.
+**DO NOT ADD FIELDS TO THE MODEL OR CHANGE TYPES OF FIELDS, FOLLOW THE PYDANTIC SCHEMA!**
+**Reformat the following information into a structured format according to the schema provided:**
+
+## Information:
+{user_input}
+
+## Pydantic Schema:
+{schema}
+
+JSON Structured Output:

--- a/agixt/prompts/Default/Web Summary.txt
+++ b/agixt/prompts/Default/Web Summary.txt
@@ -1,0 +1,6 @@
+Content of {url} to notate for the user:
+{user_input}
+
+**The assistant breaks down the content of the website into bulletpoints of important detailed notes about the content that may be important to know to a reader. It is important to not lose any of the essence of the content.**
+**If something in the content does not belong, such as a third party ad, do not include it in the notes. Do not mention the URL of the content in the notes. If the website is related to coding tutorials, return full code blocks in notes. Remember the importance of retaining as much detail as possible!**
+**The assistant should respond with well-structured notes that are detailed about the content.**

--- a/agixt/prompts/Default/WebSearch.txt
+++ b/agixt/prompts/Default/WebSearch.txt
@@ -5,6 +5,6 @@ Recent conversation history for context:
 
 Today's date is {date}. 
 
-You are a web search suggestion agent. Suggest a good web search string for the user's input. Attempt to make suggestions that will ensure top results are recent information and from reputable information sources and give proper keywords to maximize the chance of finding the information for the user's input. **Respond only with the search string and nothing else.**
-
 User's input: {user_input}
+
+The assistant is a web search suggestion agent. Suggest a good web search string for the user's input. Attempt to make suggestions that will ensure top results are recent information and from reputable information sources and give proper keywords to maximize the chance of finding the information for the user's input. **Respond only with the search string and nothing else.**

--- a/agixt/prompts/Default/WebSearch.txt
+++ b/agixt/prompts/Default/WebSearch.txt
@@ -7,4 +7,4 @@ Today's date is {date}.
 
 User's input: {user_input}
 
-The assistant is a web search suggestion agent. Suggest a good web search string for the user's input. Attempt to make suggestions that will ensure top results are recent information and from reputable information sources and give proper keywords to maximize the chance of finding the information for the user's input. **Respond only with the search string and nothing else.**
+The assistant is a web search suggestion agent. Suggest a good web search string for the user's input. Attempt to make suggestions that will ensure top results are recent information and from reputable information sources and give proper keywords to maximize the chance of finding the information for the user's input. **Respond only with the search string and nothing else. Be concise!**

--- a/agixt/prompts/Default/WebSearch.txt
+++ b/agixt/prompts/Default/WebSearch.txt
@@ -7,4 +7,4 @@ Today's date is {date}.
 
 User's input: {user_input}
 
-The assistant is a web search suggestion agent. Suggest a good web search string for the user's input. Attempt to make suggestions that will ensure top results are recent information and from reputable information sources and give proper keywords to maximize the chance of finding the information for the user's input. **Respond only with the search string and nothing else. Be concise!**
+The assistant is a web search suggestion agent. Suggest a good web search string for the user's input. Attempt to make suggestions that will ensure top results are recent information and from reputable information sources and give proper keywords to maximize the chance of finding the information for the user's input. **Respond only with the search string and nothing else. Be concise and only rephrase the user's input to create an optimal search string that will be used directly in Google search!**

--- a/agixt/prompts/Default/Website Summary.txt
+++ b/agixt/prompts/Default/Website Summary.txt
@@ -1,4 +1,0 @@
-Content of {url} to summarize for the user:
-{user_input}
-
-**Task: Summarize the content in as little text as possible without losing any details, it is important to retain details. If something in the content does not belong, such as a third party ad, do not include it in the summary. Do not summarize anything inside of code blocks, return fully populated code blocks if they exist. Do not mention the URL of the content in the summary.**

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,3 @@ python-multipart==0.0.9
 nest_asyncio
 g4f==0.3.1.9
 pyotp
-undetected-chromedriver==3.5.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,3 @@ python-multipart==0.0.9
 nest_asyncio
 g4f==0.3.1.9
 pyotp
-textacy==0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ python-multipart==0.0.9
 nest_asyncio
 g4f==0.3.1.9
 pyotp
-textacy
+textacy==0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ python-multipart==0.0.9
 nest_asyncio
 g4f==0.3.1.9
 pyotp
+textacy

--- a/static-requirements.txt
+++ b/static-requirements.txt
@@ -1,4 +1,4 @@
-chromadb==0.4.24
+chromadb==0.5.0
 beautifulsoup4==4.12.3
 docker==6.1.3
 docx2txt==0.8


### PR DESCRIPTION
Rework websearch to rotate endpoints on failure
- DuckDuckGo added some checks and limits to stop things like AI from searching on their platform. Instead of getting the vision model involved in solving a captcha to move on, I am adding additional search providers for now. 
- Brave search seems to work well so far but may also do the same thing.
- Modified searx functions and created a new `web_search` function that will rotate through a list until it finds a good working search endpoint and saves it to the agent's settings. If that one fails, it will start rotating again until it is searching properly.
- Web search will now rotates through a list of 90+ search providers until one works, then set that one as the agent's search engine until another failure happens.
- Improved keyword extraction.
- Add `convert_to_pydantic_model` function.
- Updated ChromaDB