### PR TITLE
Update README.md - Fix With EZLocalAI Missing Flag

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -111,13 +111,13 @@ python start.py
 To run AGiXT with ezLocalai, use the `--with-ezlocalai` flag:
 
 ```bash
-python start.py --with-ezlocalai
+python start.py --with-ezlocalai true
 ```
 
 You can also use command-line arguments to set specific environment variables to run in different ways. For example, to use the development branch and enable auto-updates, run:
 
 ```bash
-python start.py --agixt-branch dev --agixt-auto-update true --with-ezlocalai
+python start.py --agixt-branch dev --agixt-auto-update true --with-ezlocalai true
 ```
 
 - Access the AGiXT Management interface at <http://localhost:8501> to create and manage your agents, prompts, chains, and configurations.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# Description
Fixed With EZLocalAI Sections by adding missing "true" flag to command-line arguments.

<!--- Describe your changes in detail -->
Updated the command-line arguments for running AGiXT with ezLocalAI to include the "true" flag. This change affects both the basic usage and the example with additional arguments.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is required to ensure correct usage of the `--with-ezlocalai` flag. It solves the problem of potential misuse or confusion when running AGiXT with ezLocalAI.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The changes have been tested by running the updated commands in a local development environment to ensure they work as expected.

## Screenshots (if appropriate)
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Changes visible to users:
- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)

Internal changes:
- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] My change works!