### PR TITLE
Add Fork conversation function

### DIFF
--- a/agixt/Models.py
+++ b/agixt/Models.py
@@ -249,6 +249,11 @@ class RenameConversationModel(BaseModel):
     new_conversation_name: Optional[str] = "-"
 
 
+class ConversationFork(BaseModel):
+    conversation_name: str
+    message_id: str
+
+
 class TTSInput(BaseModel):
     text: str
 

--- a/agixt/endpoints/Conversation.py
+++ b/agixt/endpoints/Conversation.py
@@ -11,6 +11,7 @@ from Models import (
     RenameConversationModel,
     UpdateMessageModel,
     DeleteMessageModel,
+    ConversationFork,
 )
 import json
 from datetime import datetime
@@ -262,3 +263,17 @@ async def rename_conversation(
         role=rename.agent_name,
     )
     return {"conversation_name": rename.new_conversation_name}
+
+
+@app.post(
+    "/api/conversation/fork",
+    tags=["Conversation"],
+    dependencies=[Depends(verify_api_key)],
+)
+async def fork_conversation(
+    fork: ConversationFork, user=Depends(verify_api_key)
+) -> ResponseMessage:
+    new_conversation_name = Conversations(
+        conversation_name=fork.conversation_name, user=user
+    ).fork_conversation(message_id=fork.message_id)
+    return ResponseMessage(message=f"Forked conversation to {new_conversation_name}")

--- a/tests/endpoint-tests.ipynb
+++ b/tests/endpoint-tests.ipynb
@@ -742,6 +742,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Fork a Conversation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "forked_conversation = agixt.fork_conversation(\n",
+    "    conversation_name=conversation_name, message_id=conversation[1][\"id\"]\n",
+    ")\n",
+    "fork = agixt.get_conversation(\n",
+    "    agent_name=agent_name,\n",
+    "    conversation_name=forked_conversation,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Manual Conversation Message"
    ]
   },

--- a/tests/endpoint-tests.ipynb
+++ b/tests/endpoint-tests.ipynb
@@ -732,7 +732,7 @@
    ],
    "source": [
     "agent_name = \"new_agent\"\n",
-    "conversation_name = \"AGiXT Conversation\"\n",
+    "conversation_name = \"Talk for Tests\"\n",
     "conversation = agixt.get_conversation(\n",
     "    agent_name=agent_name, conversation_name=conversation_name, limit=100, page=1\n",
     ")"

--- a/tests/endpoint-tests.ipynb
+++ b/tests/endpoint-tests.ipynb
@@ -710,6 +710,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Manual Conversation Message"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agixt.new_conversation_message(\n",
+    "    role=\"USER\",\n",
+    "    conversation_name=\"AGiXT Conversation\",\n",
+    "    message=\"This is a test message from the user!\",\n",
+    ")\n",
+    "agixt.new_conversation_message(\n",
+    "    role=\"new_agent\",\n",
+    "    conversation_name=\"AGiXT Conversation\",\n",
+    "    message=\"This is a test message from the agent!\",\n",
+    ")"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -732,7 +757,7 @@
    ],
    "source": [
     "agent_name = \"new_agent\"\n",
-    "conversation_name = \"Talk for Tests\"\n",
+    "conversation_name = \"AGiXT Conversation\"\n",
     "conversation = agixt.get_conversation(\n",
     "    agent_name=agent_name, conversation_name=conversation_name, limit=100, page=1\n",
     ")"
@@ -751,28 +776,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "forked_conversation = agixt.fork_conversation(\n",
-    "    conversation_name=conversation_name, message_id=conversation[1][\"id\"]\n",
-    ")\n",
-    "fork = agixt.get_conversation(\n",
-    "    agent_name=agent_name,\n",
-    "    conversation_name=forked_conversation,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Manual Conversation Message"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "# Add an extra interaction to the conversation so that there is more than just one\n",
     "agixt.new_conversation_message(\n",
     "    role=\"USER\",\n",
     "    conversation_name=\"AGiXT Conversation\",\n",
@@ -782,6 +786,13 @@
     "    role=\"new_agent\",\n",
     "    conversation_name=\"AGiXT Conversation\",\n",
     "    message=\"This is a test message from the agent!\",\n",
+    ")\n",
+    "forked_conversation = agixt.fork_conversation(\n",
+    "    conversation_name=conversation_name, message_id=conversation[1][\"id\"]\n",
+    ")\n",
+    "fork = agixt.get_conversation(\n",
+    "    agent_name=agent_name,\n",
+    "    conversation_name=forked_conversation,\n",
     ")"
    ]
   },


### PR DESCRIPTION
Add Fork conversation function for #1238 

- Endpoint is `POST /api/conversation/fork`

Input:

```json
{
  "conversation_name": "The name of the conversation",
  "message_id": "ID of the message to fork the conversation at"
}
```

Output:

```json
{
  "message": "The new conversation name from the fork"
}
```

## Python SDK Updated

- [Python SDK updated to `v0.0.68`](https://github.com/AGiXT/python-sdk/releases/tag/v0.0.68)

Usage:

```python
from agixtsdk import AGiXTSDK

# Initialize AGiXT SDK
agixt = AGiXTSDK(base_uri="http://localhost:7437", api_key="Your API Key or JWT", verbose=True)

# Get an existing conversation
conversation_name = "Your Conversation"
conversation = agixt.get_conversation(
    agent_name=agent_name, conversation_name=conversation_name, limit=100, page=1
)

# Fork the conversation at the first response as an example, change the 1 to whichever number response you want, or use a message ID you have already.
forked_conversation = agixt.fork_conversation(
    conversation_name=conversation_name, message_id=conversation[1]["id"]
)

# Get the forked conversation interactions
fork = agixt.get_conversation(
    agent_name=agent_name,
    conversation_name=forked_conversation,
)
```