### PR TITLE
Add `get_agent_extensions` functionality

### DIFF
--- a/agixt/Extensions.py
+++ b/agixt/Extensions.py
@@ -231,7 +231,10 @@ class Extensions:
                         command_function,
                     ) in command_class.commands.items():
                         params = self.get_command_params(command_function)
-                        command_description = inspect.getdoc(command_function)
+                        try:
+                            command_description = inspect.getdoc(command_function)
+                        except:
+                            command_description = command_name
                         extension_commands.append(
                             {
                                 "friendly_name": command_name,

--- a/agixt/Extensions.py
+++ b/agixt/Extensions.py
@@ -214,6 +214,10 @@ class Extensions:
             command_class = getattr(module, module_name.lower())()
             extension_name = command_file.split("/")[-1].split(".")[0]
             extension_name = extension_name.replace("_", " ").title()
+            try:
+                extension_description = inspect.getdoc(command_class)
+            except:
+                extension_description = extension_name
             constructor = inspect.signature(command_class.__init__)
             params = constructor.parameters
             extension_settings = [
@@ -227,9 +231,11 @@ class Extensions:
                         command_function,
                     ) in command_class.commands.items():
                         params = self.get_command_params(command_function)
+                        command_description = inspect.getdoc(command_function)
                         extension_commands.append(
                             {
                                 "friendly_name": command_name,
+                                "description": command_description,
                                 "command_name": command_function.__name__,
                                 "command_args": params,
                             }
@@ -239,7 +245,7 @@ class Extensions:
             commands.append(
                 {
                     "extension_name": extension_name,
-                    "description": extension_name,
+                    "description": extension_description,
                     "settings": extension_settings,
                     "commands": extension_commands,
                 }

--- a/agixt/endpoints/Extension.py
+++ b/agixt/endpoints/Extension.py
@@ -57,7 +57,13 @@ async def get_agent_extensions(agent_name: str, user=Depends(verify_api_key)):
                 if agent_settings[key] == "" or agent_settings[key] == None:
                     new_extension["commands"] = []
         new_extensions.append(new_extension)
-    # Only give available commands if all extension keys are present
+    agent_commands = agent_config["commands"]
+    for extension in new_extensions:
+        for command in extension["commands"]:
+            if command["friendly_name"] in agent_commands:
+                command["enabled"] = agent_commands[command["friendly_name"]]
+            else:
+                command["enabled"] = False
     return {"extensions": new_extensions}
 
 

--- a/tests/endpoint-tests.ipynb
+++ b/tests/endpoint-tests.ipynb
@@ -413,6 +413,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Get Extensions Available to Agent\n",
+    "\n",
+    "This function will get a list of extensions available to the agent as well as the required settings keys and available commands per extension. If the agent does not have the settings keys for the specific extension, the list of commands will be empty."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent_extensions = agixt.get_agent_extensions(agent_name=agent_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Execute a Command\n"
    ]
   },


### PR DESCRIPTION
# Add `get_agent_extensions` functionality

The new function will get a list of extensions available to the agent as well as the required settings keys and available commands per extension. 

- If the agent does not have the settings keys for the specific extension, the list of commands will be empty. 
- Each command will also have an `enabled` boolean filled in based on the agent's settings.

## New Functions and Updates

- Added `/api/agent/{agent_name}/extensions` endpoint
- Added `get_agent_extensions` function to Python SDK and released [v0.0.69](https://github.com/AGiXT/python-sdk/releases/tag/v0.0.69)

```python
    def get_agent_extensions(self, agent_name: str = "AGiXT"):
        try:
            response = requests.get(
                headers=self.headers,
                url=f"{self.base_uri}/api/agent/{agent_name}/extensions",
            )
            if self.verbose:
                parse_response(response)
            return response.json()["extensions"]
        except Exception as e:
            return self.handle_error(e)
```

- Added `getAgentExtensions` function to [TypeScript SDK](https://github.com/AGiXT/typescript-sdk) 

```typescript
  async getAgentExtensions(agentName: string) {
    try {
      const response = await axios.get<{ extensions: any[] }>(`${this.baseUri}/api/agent/${agentName}/extensions`, { headers: this.headers });
      return response.data.extensions;
    } catch (error) {
      return this.handleError(error);
    }
  }
```

- Added test for the new function to [endpoint-tests.ipynb](https://github.com/Josh-XT/AGiXT/blob/main/tests/endpoint-tests.ipynb)
- Modified the `description` field for the extensions to use the DocuString for the extension if one exists. I will do another PR to add DocuStrings to all extensions in the near future.
- Added a `description` field to the `command` dictionary that uses the DocuString for the command if one exists.
```python
{
    "friendly_name": "The friendly command name",
    "description": "The docustring for the command",
    "command_name": command_function.__name__,
    "command_args": params,
}
```

## Example output

This agent has no extensions enabled, which is reflected correctly. The `description` field says `None` on all of these currently, but will be remedied in another PR to add DocuStrings to all extensions with explanations of the extension.

```json
{
    "extensions": [
        {
            "extension_name": "Microsoft365",
            "description": "None",
            "settings": [
                "M365_CLIENT_ID",
                "M365_CLIENT_SECRET",
                "M365_TENANT_ID"
            ],
            "commands": []
        },
        {
            "extension_name": "Microsoft365",
            "description": "None",
            "settings": [
                "M365_CLIENT_ID",
                "M365_CLIENT_SECRET",
                "M365_TENANT_ID"
            ],
            "commands": []
        },
        {
            "extension_name": "Mysql Database",
            "description": "None",
            "settings": [
                "MYSQL_DATABASE_NAME",
                "MYSQL_DATABASE_HOST",
                "MYSQL_DATABASE_PORT",
                "MYSQL_DATABASE_USERNAME",
                "MYSQL_DATABASE_PASSWORD"
            ],
            "commands": []
        },
        {
            "extension_name": "Mysql Database",
            "description": "None",
            "settings": [
                "MYSQL_DATABASE_NAME",
                "MYSQL_DATABASE_HOST",
                "MYSQL_DATABASE_PORT",
                "MYSQL_DATABASE_USERNAME",
                "MYSQL_DATABASE_PASSWORD"
            ],
            "commands": []
        },
        {
            "extension_name": "Google",
            "description": "None",
            "settings": [
                "GOOGLE_API_KEY",
                "GOOGLE_SEARCH_ENGINE_ID"
            ],
            "commands": []
        },
        {
            "extension_name": "Discord",
            "description": "None",
            "settings": [
                "DISCORD_API_KEY",
                "DISCORD_COMMAND_PREFIX"
            ],
            "commands": []
        },
        {
            "extension_name": "Sendgrid Email",
            "description": "None",
            "settings": [
                "SENDGRID_API_KEY",
                "SENDGRID_EMAIL"
            ],
            "commands": []
        },
        {
            "extension_name": "Github",
            "description": "None",
            "settings": [
                "GITHUB_USERNAME",
                "GITHUB_API_KEY"
            ],
            "commands": []
        },
        {
            "extension_name": "Github",
            "description": "None",
            "settings": [
                "GITHUB_USERNAME",
                "GITHUB_API_KEY"
            ],
            "commands": []
        },
        {
            "extension_name": "Postgres Database",
            "description": "None",
            "settings": [
                "POSTGRES_DATABASE_NAME",
                "POSTGRES_DATABASE_HOST",
                "POSTGRES_DATABASE_PORT",
                "POSTGRES_DATABASE_USERNAME",
                "POSTGRES_DATABASE_PASSWORD"
            ],
            "commands": []
        },
        {
            "extension_name": "Sqlite Database",
            "description": "None",
            "settings": [
                "SQLITE_DATABASE_PATH"
            ],
            "commands": []
        },
        {
            "extension_name": "Oura",
            "description": "None",
            "settings": [
                "OURA_API_KEY"
            ],
            "commands": []
        },
        {
            "extension_name": "File System",
            "description": "None",
            "settings": [
                "WORKING_DIRECTORY",
                "WORKING_DIRECTORY_RESTRICTED"
            ],
            "commands": []
        }
    ]
}
```