### PR TITLE
Add automatic translations

### DIFF
--- a/agixt/Models.py
+++ b/agixt/Models.py
@@ -281,6 +281,10 @@ class UpdateMessageModel(BaseModel):
     new_message: str
 
 
+class TranslationRequest(BaseModel):
+    target_language_translated_text: str
+
+
 class DeleteMessageModel(BaseModel):
     conversation_name: str
 

--- a/agixt/XT.py
+++ b/agixt/XT.py
@@ -1223,6 +1223,7 @@ class AGiXT:
         browse_links = True
         tts = False
         websearch = False
+        language = "en"
 
         if "websearch" in self.agent_settings:
             websearch = str(self.agent_settings["websearch"]).lower() == "true"
@@ -1238,6 +1239,8 @@ class AGiXT:
             prompt_category = self.agent_settings["prompt_category"]
         else:
             prompt_category = "Default"
+        if "LANGUAGE" in self.agent_settings:
+            language = str(self.agent_settings["LANGUAGE"]).lower()
         prompt_args = {}
         if "prompt_args" in self.agent_settings:
             prompt_args = (
@@ -1298,6 +1301,8 @@ class AGiXT:
                     mode = message["mode"]
             if "injected_memories" in message:
                 context_results = int(message["injected_memories"])
+            if "language" in message:
+                language = message["language"]
             if "conversation_results" in message:
                 conversation_results = int(message["conversation_results"])
             if "prompt_category" in message:
@@ -1644,11 +1649,8 @@ class AGiXT:
             if current_input_tokens < self.agent.max_input_tokens:
                 if file_content:
                     prompt_args["uploaded_file_data"] = file_content
-            language = "en"
-            if "LANGUAGE" in self.agent_settings:
-                language = str(self.agent_settings["LANGUAGE"]).lower()
-                if len(language) > 2:
-                    language = language[:2]
+            if len(language) > 2:
+                language = language[:2]
             response = await self.inference(
                 user_input=new_prompt,
                 prompt_name=prompt_name,

--- a/agixt/XT.py
+++ b/agixt/XT.py
@@ -244,8 +244,9 @@ class AGiXT:
                 text=target_language_user_input.target_language_translated_text,
                 log_output=True,
             )
+        stripped_response = re.sub(r"```[^```]+```", "", response)
         target_language_response = await self.convert_to_model(
-            input_string=f"{translation_prompt}{response}",
+            input_string=f"{translation_prompt}{stripped_response}",
             model=TranslationRequest,
         )
         new_response = f"{response}\n**Translated to {language.upper()}**\n{target_language_response.target_language_translated_text}"

--- a/agixt/providers/ezlocalai.py
+++ b/agixt/providers/ezlocalai.py
@@ -28,7 +28,7 @@ class EzlocalaiProvider:
         AI_TEMPERATURE: float = 1.33,
         AI_TOP_P: float = 0.95,
         VOICE: str = "HAL9000",
-        TTS_LANGUAGE: str = "en",
+        LANGUAGE: str = "en",
         TRANSCRIPTION_MODEL: str = "base",
         **kwargs,
     ):
@@ -41,7 +41,9 @@ class EzlocalaiProvider:
             EZLOCALAI_API_URI if EZLOCALAI_API_URI else getenv("EZLOCALAI_URI")
         )
         self.VOICE = VOICE if VOICE else "HAL9000"
-        self.TTS_LANGUAGE = TTS_LANGUAGE if TTS_LANGUAGE else "en"
+        self.TTS_LANGUAGE = LANGUAGE if LANGUAGE else "en"
+        if len(self.TTS_LANGUAGE) > 2:
+            self.TTS_LANGUAGE = self.TTS_LANGUAGE[:2].lower()
         self.OUTPUT_URL = self.API_URI.replace("/v1/", "") + "/outputs/"
         self.AI_TEMPERATURE = AI_TEMPERATURE if AI_TEMPERATURE else 1.33
         self.AI_TOP_P = AI_TOP_P if AI_TOP_P else 0.95


### PR DESCRIPTION
## Add automatic translations

- Added an agent setting for `LANGUAGE` that will allow you to set a language other than English to receive agent responses in. 
  - For example, if your agent's language is set to `ru`, it will allow the user to write to the agent in English and receive text output in Russian. This would include the English response as well as the Russian response.
  - If you're using `ezLocalai` or another text to speech provider (will expand on this later) for your agent and have it enabled, you will get an output of what you said in the target language as well as the response audio in the target language.
- Improved the function that converts pydantic models to text schemas.
- Currently, the LLM associated with the agent currently is set to handle the text translation, I'm assuming there are significantly better methods for doing this, so the inner workings will likely change to a local language translation module.

The goal of this PR is to assist in the use case of language learning since I've recently taken an interest.