### PR TITLE
Deduplicate memories existing by external sources

### DIFF
--- a/agixt/Memories.py
+++ b/agixt/Memories.py
@@ -88,7 +88,7 @@ def query_results_to_records(results: "QueryResult"):
         return []
     memory_records = [
         {
-            "external_source_name": metadata["external_source_name"],
+            "external_source_name": metadata.get("external_source_name", "user input"),
             "id": metadata["id"],
             "description": metadata["description"],
             "text": document,

--- a/agixt/Memories.py
+++ b/agixt/Memories.py
@@ -415,24 +415,28 @@ class Memories:
         if text:
             if not isinstance(text, str):
                 text = str(text)
-            # Check for file-based duplicates
-            if external_source.startswith("file"):
+            # Check for duplicates from external sources (files or URLs)
+            if external_source.startswith(("file", "http://", "https://")):
                 try:
                     # Get all external sources in this collection
                     existing_sources = await self.get_external_data_sources()
-                    # Check if this file already exists in memory
+
+                    # Check if this source already exists in memory
                     for source in existing_sources:
                         if source == external_source:
                             logging.info(
-                                f"Found existing file in memory: {external_source}"
+                                f"Found existing content in memory from source: {external_source}"
                             )
-                            # Delete existing memories for this file
+                            # Delete existing memories for this source
                             await self.delete_memories_from_external_source(
                                 external_source
                             )
+                            logging.info(
+                                f"Deleted existing content from source: {external_source}"
+                            )
                             break
                 except Exception as e:
-                    logging.warning(f"Error checking for existing file content: {e}")
+                    logging.warning(f"Error checking for existing content: {e}")
             if self.summarize_content:
                 text = await self.summarize_text(text=text)
             chunks = await self.chunk_content(text=text, chunk_size=self.chunk_size)

--- a/agixt/Memories.py
+++ b/agixt/Memories.py
@@ -409,12 +409,10 @@ class Memories:
     async def write_text_to_memory(
         self, user_input: str, text: str, external_source: str = "user input"
     ):
-        """Write text to memory with file-based deduplication check"""
+        # Log the collection number and agent name
         logging.info(f"Saving to collection name: {self.collection_name}")
         collection = await self.get_collection()
         if text:
-            if isinstance(text, dict):
-                text = json.dumps(text, indent=4)
             if not isinstance(text, str):
                 text = str(text)
             # Check for file-based duplicates


### PR DESCRIPTION
This pull request includes a significant update to the `agixt/Memories.py` file, specifically enhancing the `write_text_to_memory` function to handle duplicate content from external sources. The most important changes are:

Enhancements to duplicate content handling:

* Added logic to check for duplicates from external sources such as files or URLs. If a duplicate is found, the existing content from that source is deleted before writing the new content. This ensures that the memory does not contain redundant information.