### PR TITLE
Add more detailed conversation endpoints

### DIFF
--- a/agixt/Conversations.py
+++ b/agixt/Conversations.py
@@ -114,6 +114,33 @@ class Conversations:
         session.close()
         return result
 
+    def get_conversations_with_detail(self):
+        session = get_session()
+        user_data = session.query(User).filter(User.email == self.user).first()
+        user_id = user_data.id
+
+        # Use a LEFT OUTER JOIN to get conversations and their messages
+        conversations = (
+            session.query(Conversation)
+            .outerjoin(Message, Message.conversation_id == Conversation.id)
+            .filter(Conversation.user_id == user_id)
+            .filter(Message.id != None)  # Only get conversations with messages
+            .order_by(Conversation.updated_at.desc())
+            .distinct()
+            .all()
+        )
+
+        result = {
+            str(conversation.id): {
+                "name": conversation.name,
+                "created_at": conversation.created_at,
+                "updated_at": conversation.updated_at,
+            }
+            for conversation in conversations
+        }
+        session.close()
+        return result
+
     def get_conversation(self, limit=100, page=1):
         session = get_session()
         user_data = session.query(User).filter(User.email == self.user).first()

--- a/agixt/Models.py
+++ b/agixt/Models.py
@@ -231,7 +231,7 @@ class AgentCommands(BaseModel):
 
 class HistoryModel(BaseModel):
     agent_name: str
-    conversation_name: str
+    conversation_name: Optional[str] = "-"
     limit: int = 100
     page: int = 1
 

--- a/agixt/Models.py
+++ b/agixt/Models.py
@@ -231,7 +231,7 @@ class AgentCommands(BaseModel):
 
 class HistoryModel(BaseModel):
     agent_name: str
-    conversation_name: Optional[str] = "-"
+    conversation_name: Optional[str] = None
     limit: int = 100
     page: int = 1
 


### PR DESCRIPTION
This pull request introduces several changes to enhance the conversation management feature in the `agixt` project. The most important changes include adding a new method to retrieve detailed conversations, updating the `HistoryModel` to make `conversation_name` optional, and adding new endpoints for fetching conversation details and history.

### Enhancements to conversation management:

* Added `get_conversations_with_detail` method in `Conversations.py` to retrieve conversations along with their messages using a LEFT OUTER JOIN.
* Updated `HistoryModel` in `Models.py` to make `conversation_name` an optional field.

### Updates to endpoints:

* Modified imports in `Conversation.py` to include `get_conversation_name_by_id` from `Conversations` and `MagicalAuth`. [[1]](diffhunk://#diff-ab7556e3f67cbeadf9f9bb4966a9d7ebc94a8194b866cd5068eb7b543e194facL2-R3) [[2]](diffhunk://#diff-ab7556e3f67cbeadf9f9bb4966a9d7ebc94a8194b866cd5068eb7b543e194facR19)
* Added new endpoint `/v1/conversations` to fetch a list of conversations with details.
* Added new endpoint `/v1/conversation/{conversation_id}` to fetch the history of a specific conversation.