### PR TITLE
Fix #1303: Move Token Count Logging from XT.py to Agent.py

### DIFF
--- a/agixt/Agent.py
+++ b/agixt/Agent.py
@@ -369,11 +369,32 @@ class Agent:
         return config
 
     async def inference(self, prompt: str, tokens: int = 0, images: list = []):
+
+        try:
+        self.input_tokens = get_tokens(prompt)
+        except Exception as e:
+        self.input_tokens = 0
+        logging.error(f"Error getting tokens: {e}")
+
         if not prompt:
             return ""
         answer = await self.PROVIDER.inference(
             prompt=prompt, tokens=tokens, images=images
         )
+
+            try:
+            output_tokens = get_tokens(answer)
+            except Exception as e:
+            output_tokens = 0
+            logging.error(f"Error getting tokens: {e}")
+            try:
+            self.auth.increase_token_counts(
+            input_tokens=self.input_tokens,
+            output_tokens=output_tokens,
+            )
+            except Exception as e:
+            logging.warning(f"Error increasing token counts: {e}")
+
         answer = str(answer).replace("\_", "_")
         if answer.endswith("\n\n"):
             answer = answer[:-2]


### PR DESCRIPTION
Resolves #1303

The following modifications were applied:


 ```xml
 ```xml
<modification>
  <file>agixt/Agent.py</file>
  <operation>insert</operation>
  <target>        if not prompt:</target>
  <content>
        try:
            self.input_tokens = get_tokens(prompt)
        except Exception as e:
            self.input_tokens = 0
            logging.error(f"Error getting tokens: {e}")
  </content>
 </modification>
```
 ```xml
<modification>
  <file>agixt/Agent.py</file>
  <operation>insert</operation>
  <target>        answer = str(answer).replace("_", "_")</target>
  <content>
        try:
            output_tokens = get_tokens(answer)
        except Exception as e:
            output_tokens = 0
            logging.error(f"Error getting tokens: {e}")
        try:
            self.auth.increase_token_counts(
                input_tokens=self.input_tokens,
                output_tokens=output_tokens,
            )
        except Exception as e:
            logging.warning(f"Error increasing token counts: {e}")
  </content>
 </modification>
```
 ```xml
<modification>
  <file>agixt/XT.py</file>
  <operation>replace</operation>
  <target>        response = await self.agent.inference(
            prompt=prompt, tokens=tokens, images=images
        )
        answer = str(answer).replace("_", "_")</target>
  <content>        response = await self.agent.inference(
            prompt=prompt, tokens=tokens, images=images
        )
        answer = str(response).replace("_", "_")</content>
 </modification>
```
 ```xml
<modification>
  <file>agixt/XT.py</file>
  <operation>insert</operation>
  <target>        if log_output:</target>
  <content>
        try:
            prompt_tokens = get_tokens(new_prompt) + self.input_tokens
            completion_tokens = get_tokens(response)
            total_tokens = int(prompt_tokens) + int(completion_tokens)
            logging.info(f"Input tokens: {prompt_tokens}")
            logging.info(f"Completion tokens: {completion_tokens}")
            logging.info(f"Total tokens: {total_tokens}")
        except:
            if not response:
                response = "Unable to retrieve response."
                logging.error(f"Error getting response: {response}")
        try:
            self.auth.increase_token_counts(
                input_tokens=prompt_tokens,
                output_tokens=completion_tokens,
            )
        except Exception as e:
            logging.warning(f"Error increasing token counts: {e}")
  </content>
 </modification>
```
  ```xml
<modification>
  <file>agixt/XT.py</file>
  <operation>insert</operation>
  <target>            "choices": [
                {
                    "index": 0,
                    "message": {
                        "role": "assistant",
                        "content": str(response),
                    },</target>
  <content>
                    "usage": {
                        "prompt_tokens": prompt_tokens,
                        "completion_tokens": completion_tokens,
                        "total_tokens": total_tokens,
                    },
   </content>
 </modification>
```
 ```
 