### PR TITLE
Fix #1303: Move Token Count Logging from XT.py to Agent.py

### DIFF
--- a/agixt/Agent.py
+++ b/agixt/Agent.py
@@ -377,6 +377,26 @@ class Agent:
         answer = str(answer).replace("\_", "_")
         if answer.endswith("\n\n"):
             answer = answer[:-2]
+
+        try:
+                    prompt_tokens = get_tokens(prompt)
+                    completion_tokens = get_tokens(answer)
+                    total_tokens = int(prompt_tokens) + int(completion_tokens)
+                    logging.info(f"Input tokens: {prompt_tokens}")
+                    logging.info(f"Completion tokens: {completion_tokens}")
+                    logging.info(f"Total tokens: {total_tokens}")
+                except:
+                    pass
+                try:
+                    if hasattr(self.PROVIDER, "ApiClient") and self.PROVIDER.ApiClient != None:
+                        self.PROVIDER.ApiClient.increase_token_counts(
+                            input_tokens=prompt_tokens,
+                            output_tokens=completion_tokens,
+                        )
+                except Exception as e:
+                    logging.warning(f"Error increasing token counts: {e}")
+                return answer
+
         return answer
 
     async def vision_inference(self, prompt: str, tokens: int = 0, images: list = []):

--- a/agixt/XT.py
+++ b/agixt/XT.py
@@ -1845,24 +1845,12 @@ class AGiXT:
                     role=self.agent_name,
                     message=response,
                 )
-        try:
-            prompt_tokens = get_tokens(new_prompt) + self.input_tokens
-            completion_tokens = get_tokens(response)
-            total_tokens = int(prompt_tokens) + int(completion_tokens)
-            logging.info(f"Input tokens: {prompt_tokens}")
-            logging.info(f"Completion tokens: {completion_tokens}")
-            logging.info(f"Total tokens: {total_tokens}")
-        except:
-            if not response:
-                response = "Unable to retrieve response."
-                logging.error(f"Error getting response: {response}")
-        try:
-            self.auth.increase_token_counts(
-                input_tokens=prompt_tokens,
-                output_tokens=completion_tokens,
-            )
-        except Exception as e:
-            logging.warning(f"Error increasing token counts: {e}")
+                    try:
+                                if not response:
+                                    response = "Unable to retrieve response."
+                                    logging.error(f"Error getting response: {response}")
+                            except:
+                                pass
         response = self.remove_tagged_content(response, "execute")
         response = self.remove_tagged_content(response, "output")
         res_model = {


### PR DESCRIPTION
Resolves #1303

The following modifications were applied:


I have moved the token count logging functionality from `XT.py` to `Agent.py` in the `inference` function. Here are the modifications:

```xml
```xml
<modification>
<file>agixt/XT.py</file>
<operation>replace</operation>
<target>
        try:
            prompt_tokens = get_tokens(new_prompt) + self.input_tokens
            completion_tokens = get_tokens(response)
            total_tokens = int(prompt_tokens) + int(completion_tokens)
            logging.info(f"Input tokens: {prompt_tokens}")
            logging.info(f"Completion tokens: {completion_tokens}")
            logging.info(f"Total tokens: {total_tokens}")
        except:
            if not response:
                response = "Unable to retrieve response."
                logging.error(f"Error getting response: {response}")
        try:
            self.auth.increase_token_counts(
                input_tokens=prompt_tokens,
                output_tokens=completion_tokens,
            )
        except Exception as e:
            logging.warning(f"Error increasing token counts: {e}")
</target>
<content>
        try:
            if not response:
                response = "Unable to retrieve response."
                logging.error(f"Error getting response: {response}")
        except:
            pass
</content>
</modification>
```
```xml
<modification>
<file>agixt/Agent.py</file>
<operation>insert</operation>
<target>        return answer</target>
<content>
        try:
            prompt_tokens = get_tokens(prompt)
            completion_tokens = get_tokens(answer)
            total_tokens = int(prompt_tokens) + int(completion_tokens)
            logging.info(f"Input tokens: {prompt_tokens}")
            logging.info(f"Completion tokens: {completion_tokens}")
            logging.info(f"Total tokens: {total_tokens}")
        except:
            pass
        try:
            if hasattr(self.PROVIDER, "ApiClient") and self.PROVIDER.ApiClient != None:
                self.PROVIDER.ApiClient.increase_token_counts(
                    input_tokens=prompt_tokens,
                    output_tokens=completion_tokens,
                )
        except Exception as e:
            logging.warning(f"Error increasing token counts: {e}")
        return answer
</content>
</modification>
```
```
