### PR TITLE
Fix #1303: Move Token Count Logging from XT.py to Agent.py

### DIFF
--- a/agixt/Agent.py
+++ b/agixt/Agent.py
@@ -392,6 +392,18 @@ class Agent:
             answer = answer[:-2]
         return answer
 
+        async def calculate_tokens(self, prompt: str, response: str):
+        try:
+        prompt_tokens = get_tokens(prompt)
+        completion_tokens = get_tokens(response)
+        total_tokens = int(prompt_tokens) + int(completion_tokens)
+        logging.info(f"Input tokens: {prompt_tokens}")
+        logging.info(f"Completion tokens: {completion_tokens}")
+        logging.info(f"Total tokens: {total_tokens}")
+        return prompt_tokens, completion_tokens, total_tokens
+        except:
+        return 0, 0, 0
+
     def embeddings(self, input) -> np.ndarray:
         return self.embedder(input=input)
 

--- a/agixt/XT.py
+++ b/agixt/XT.py
@@ -1845,14 +1845,8 @@ class AGiXT:
                     role=self.agent_name,
                     message=response,
                 )
-        try:
-            prompt_tokens = get_tokens(new_prompt) + self.input_tokens
-            completion_tokens = get_tokens(response)
-            total_tokens = int(prompt_tokens) + int(completion_tokens)
-            logging.info(f"Input tokens: {prompt_tokens}")
-            logging.info(f"Completion tokens: {completion_tokens}")
-            logging.info(f"Total tokens: {total_tokens}")
-        except:
+                    try :
+                    prompt_tokens, completion_tokens, total_tokens = await self.agent.calculate_tokens(prompt=new_prompt, response=response)
             if not response:
                 response = "Unable to retrieve response."
                 logging.error(f"Error getting response: {response}")


### PR DESCRIPTION
Resolves #1303

The following modifications were applied:


```xml
<modification>
<file>agixt/XT.py</file>
<operation>replace</operation>
<target>try :
    prompt_tokens = get_tokens(new_prompt) + self.input_tokens
    completion_tokens = get_tokens(response)
    total_tokens = int(prompt_tokens) + int(completion_tokens)
    logging.info(f"Input tokens: {prompt_tokens}")
    logging.info(f"Completion tokens: {completion_tokens}")
    logging.info(f"Total tokens: {total_tokens}")
except :</target>
<content>try :
    prompt_tokens, completion_tokens, total_tokens = await self.agent.calculate_tokens(prompt=new_prompt, response=response)
</content>
</modification>
```

```xml
<modification>
<file>agixt/Agent.py</file>
<operation>insert</operation>
<target>async def vision_inference(self, prompt: str, tokens: int = 0, images: list = []):</target>
<content>
async def calculate_tokens(self, prompt: str, response: str):
    try:
        prompt_tokens = get_tokens(prompt)
        completion_tokens = get_tokens(response)
        total_tokens = int(prompt_tokens) + int(completion_tokens)
        logging.info(f"Input tokens: {prompt_tokens}")
        logging.info(f"Completion tokens: {completion_tokens}")
        logging.info(f"Total tokens: {total_tokens}")
        return prompt_tokens, completion_tokens, total_tokens
    except:
        return 0, 0, 0
</content>
</modification>
```
