### PR TITLE
Fix #1303: Move Token Count Logging from XT.py to Agent.py

### DIFF
--- a/agixt/Agent.py
+++ b/agixt/Agent.py
@@ -374,6 +374,23 @@ class Agent:
         answer = await self.PROVIDER.inference(
             prompt=prompt, tokens=tokens, images=images
         )
+
+        try:
+            user_id = self.user_id
+            prompt_tokens = get_tokens(prompt)
+            completion_tokens = get_tokens(answer)
+            total_tokens = int(prompt_tokens) + int(completion_tokens)
+            logging.info(f"Input tokens: {prompt_tokens}")
+            logging.info(f"Completion tokens: {completion_tokens}")
+            logging.info(f"Total tokens: {total_tokens}")
+            if user_id:
+                MagicalAuth(token=None).increase_token_counts(
+                    input_tokens=prompt_tokens,
+                    output_tokens=completion_tokens,
+                )
+        except Exception as e:
+            logging.warning(f"Error increasing token counts: {e}")
+
         answer = str(answer).replace("\_", "_")
         if answer.endswith("\n\n"):
             answer = answer[:-2]

--- a/agixt/XT.py
+++ b/agixt/XT.py
@@ -554,7 +554,21 @@ class AGiXT:
             )
             return result
         else:
-            return None
+        try:
+            prompt_tokens = get_tokens(prompt)
+            completion_tokens = get_tokens(answer)
+            total_tokens = int(prompt_tokens) + int(completion_tokens)
+            logging.info(f"Input tokens: {prompt_tokens}")
+            logging.info(f"Completion tokens: {completion_tokens}")
+            logging.info(f"Total tokens: {total_tokens}")
+            if self.auth.user_id:
+                self.auth.increase_token_counts(
+                    input_tokens=prompt_tokens,
+                    output_tokens=completion_tokens,
+                )
+        except Exception as e:
+            logging.warning(f"Error increasing token counts: {e}")
+        return answer
 
     async def execute_chain(
         self,


### PR DESCRIPTION
Resolves #1303

The following modifications were applied:


```xml
```xml
<modification>
<file>agixt/XT.py</file>
<operation>replace</operation>
<target>        return answer
</target>
<content>        try:
            prompt_tokens = get_tokens(prompt)
            completion_tokens = get_tokens(answer)
            total_tokens = int(prompt_tokens) + int(completion_tokens)
            logging.info(f"Input tokens: {prompt_tokens}")
            logging.info(f"Completion tokens: {completion_tokens}")
            logging.info(f"Total tokens: {total_tokens}")
            if self.auth.user_id:
                self.auth.increase_token_counts(
                    input_tokens=prompt_tokens,
                    output_tokens=completion_tokens,
                )
        except Exception as e:
            logging.warning(f"Error increasing token counts: {e}")
        return answer</content>
</modification>
```
```xml
<modification>
<file>agixt/Agent.py</file>
<operation>insert</operation>
<target>        answer = str(answer).replace("_", "_")
        if answer.endswith("\n\n"):
            answer = answer[:-2]
        return answer</target>
<content>        try:
            user_id = self.user_id
            prompt_tokens = get_tokens(prompt)
            completion_tokens = get_tokens(answer)
            total_tokens = int(prompt_tokens) + int(completion_tokens)
            logging.info(f"Input tokens: {prompt_tokens}")
            logging.info(f"Completion tokens: {completion_tokens}")
            logging.info(f"Total tokens: {total_tokens}")
            if user_id:
                MagicalAuth(token=None).increase_token_counts(
                    input_tokens=prompt_tokens,
                    output_tokens=completion_tokens,
                )
        except Exception as e:
            logging.warning(f"Error increasing token counts: {e}")</content>
</modification>
```
```
