### PR TITLE
Add notifications

### DIFF
--- a/agixt/Conversations.py
+++ b/agixt/Conversations.py
@@ -304,9 +304,10 @@ class Conversations:
                 updated_at=message.updated_at,
                 updated_by=message.updated_by,
                 feedback_received=message.feedback_received,
+                notify=False,
             )
             session.add(new_message)
-
+        new_message.notify = True  # Notify on the last message
         session.commit()
         forked_conversation_id = str(new_conversation.id)
         session.close()
@@ -582,6 +583,7 @@ class Conversations:
         return str(thinking_id)
 
     def log_interaction(self, role, message):
+        message = str(message)
         if str(message).startswith("[SUBACTIVITY] "):
             try:
                 last_activity_id = self.get_last_activity_id()
@@ -604,8 +606,14 @@ class Conversations:
             )
             .first()
         )
+        notify = False
         if role.lower() == "user":
             role = "USER"
+        else:
+            if not message.startswith("[ACTIVITY]") and not message.startswith(
+                "[SUBACTIVITY]"
+            ):
+                notify = True
         if not conversation:
             conversation = self.new_conversation()
             session.close()
@@ -615,6 +623,7 @@ class Conversations:
                 role=role,
                 content=message,
                 conversation_id=conversation.id,
+                notify=notify,
             )
             # Update the conversation's updated_at timestamp
             conversation.updated_at = func.now()
@@ -626,6 +635,7 @@ class Conversations:
                 role=role,
                 content=message,
                 conversation_id=conversation.id,
+                notify=notify,
             )
             # Update the conversation's updated_at timestamp
             conversation.updated_at = func.now()

--- a/agixt/DB.py
+++ b/agixt/DB.py
@@ -324,6 +324,7 @@ class Message(Base):
         nullable=True,
     )
     feedback_received = Column(Boolean, default=False)
+    notify = Column(Boolean, default=False, nullable=False)
 
 
 class Setting(Base):

--- a/agixt/endpoints/Conversation.py
+++ b/agixt/endpoints/Conversation.py
@@ -362,3 +362,14 @@ async def get_tts(
     )
     c.update_message_by_id(message_id=message_id, new_message=new_message)
     return {"message": new_message}
+
+
+@app.get(
+    "/api/notifications",
+    tags=["Conversation"],
+    dependencies=[Depends(verify_api_key)],
+)
+async def get_notifications(user=Depends(verify_api_key)):
+    c = Conversations(user=user)
+    notifications = c.get_notifications()
+    return {"notifications": notifications}


### PR DESCRIPTION
This pull request introduces several enhancements to the conversation management system, focusing on notification handling and message logging. The most important changes include adding notification checks to conversation queries, implementing a method to retrieve notifications, and updating the message logging process to handle notifications.

Enhancements to conversation management:

* [`agixt/Conversations.py`](diffhunk://#diff-791e06557a48c657e0d1c3eac5aca99792f28772835f5dd7d08d9b3e64929e26L122-L129): Modified `get_conversations_with_detail` to include a notification count for each conversation and added a `has_notifications` field to the result. [[1]](diffhunk://#diff-791e06557a48c657e0d1c3eac5aca99792f28772835f5dd7d08d9b3e64929e26L122-L129) [[2]](diffhunk://#diff-791e06557a48c657e0d1c3eac5aca99792f28772835f5dd7d08d9b3e64929e26R143-R179)
* [`agixt/Conversations.py`](diffhunk://#diff-791e06557a48c657e0d1c3eac5aca99792f28772835f5dd7d08d9b3e64929e26R143-R179): Added a new method `get_notifications` to retrieve all messages with notifications for a user's conversations.

Notification handling improvements:

* [`agixt/Conversations.py`](diffhunk://#diff-791e06557a48c657e0d1c3eac5aca99792f28772835f5dd7d08d9b3e64929e26R199-R208): Updated `get_conversation` to mark all notifications as read when a conversation is accessed.
* [`agixt/Conversations.py`](diffhunk://#diff-791e06557a48c657e0d1c3eac5aca99792f28772835f5dd7d08d9b3e64929e26R307-R310): Modified `fork_conversation` to ensure the last message in a forked conversation has notifications enabled.
* [`agixt/DB.py`](diffhunk://#diff-acf19d17ca6b49f3682c2080cbd20d6460a9867390a2d65408da7a07fad6ee2cR327): Added a `notify` column to the `Message` class to track notification status.

These changes improve the overall functionality and user experience by providing better notification management and ensuring important messages are highlighted.