### PR TITLE
Fix code scanning alert no. 316: Uncontrolled data used in path expression

### DIFF
--- a/agixt/Memories.py
+++ b/agixt/Memories.py
@@ -595,8 +595,10 @@ class Memories:
         logging.info(f"Starting deletion for source: {external_source}")  # Debug print
         if external_source.startswith("file"):
             file_path = external_source.split(" ")[1]
-            # Make sure the file path starts with the working directory
-            working_directory = getenv("WORKING_DIRECTORY")
+            # Normalize the file path
+            file_path = os.path.normpath(file_path)
+            # Make sure the file path is contained within the working directory
+            working_directory = os.path.normpath(getenv("WORKING_DIRECTORY"))
             if file_path.startswith(working_directory):
                 # Delete it
                 try:


### PR DESCRIPTION
Fixes [https://github.com/Josh-XT/AGiXT/security/code-scanning/316](https://github.com/Josh-XT/AGiXT/security/code-scanning/316)

To fix the problem, we need to ensure that the `file_path` derived from `external_source` is properly validated and sanitized. We can achieve this by normalizing the `file_path` and ensuring it is contained within the `working_directory`. This will prevent directory traversal attacks and ensure that only files within the intended directory can be deleted.

1. Normalize the `file_path` using `os.path.normpath` to remove any ".." segments.
2. Check that the normalized `file_path` starts with the `working_directory`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
