### PR TITLE
S3 Workspaces

### DIFF
--- a/agixt/Agent.py
+++ b/agixt/Agent.py
@@ -26,6 +26,7 @@ from MagicalAuth import MagicalAuth, get_user_id
 from agixtsdk import AGiXTSDK
 from fastapi import HTTPException
 from datetime import datetime, timezone, timedelta
+from Workspaces import workspace_manager
 import logging
 import json
 import numpy as np

--- a/agixt/Workspaces.py
+++ b/agixt/Workspaces.py
@@ -252,4 +252,4 @@ class WorkspaceManager:
 
 
 # Create a singleton instance
-# workspace_manager = WorkspaceManager()
+workspace_manager = WorkspaceManager()


### PR DESCRIPTION
The goal in this PR is to switch from locally persisted agent workspaces to putting them in S3 storage. Anyone deploying locally will be able to use a minio container, which will be added to the docker-compose files for anyone running locally. This PR will effectively enable deploying AGiXT on cloud services hosts such as AWS or Digital Ocean without the need to persist files.