### PR TITLE
Fix #1371 : Chain Query `too many values`

### DIFF
--- a/agixt/endpoints/GQL.py
+++ b/agixt/endpoints/GQL.py
@@ -1851,7 +1851,7 @@ class Query:
     @strawberry.field
     async def providers(self, info) -> Providers:
         """Get comprehensive provider details"""
-        user = await get_user_from_context(info)
+        user, auth, magical = await get_user_from_context(info)
         provider_details = get_providers_with_details()
         providers = [
             convert_provider_details({"name": name, **details})
@@ -2143,7 +2143,7 @@ class Query:
     @strawberry.field
     async def command_args(self, info, command_name: str) -> CommandArgs:
         """Get arguments for a specific command"""
-        user, _ = await get_user_from_context(info)
+        user, auth, magical = await get_user_from_context(info)
 
         extensions = Extensions()
         raw_args = extensions.get_command_args(command_name=command_name)
@@ -2280,7 +2280,7 @@ class Query:
     @strawberry.field
     async def chain(self, info, chain_name: str) -> ChainConfig:
         """Get details of a specific chain"""
-        user, _ = await get_user_from_context(info)
+        user, auth, magical = await get_user_from_context(info)
 
         chain_manager = Chain(user=user)
         chain_data = chain_manager.get_chain(chain_name=chain_name)
@@ -2316,7 +2316,7 @@ class Query:
     @strawberry.field
     async def chain_dependencies(self, info, chain_name: str) -> List[ChainDependency]:
         """Get dependencies between chain steps"""
-        user, _ = await get_user_from_context(info)
+        user, auth, magical = await get_user_from_context(info)
 
         chain_manager = Chain(user=user)
         deps = chain_manager.get_chain_step_dependencies(chain_name=chain_name)


### PR DESCRIPTION
This pull request includes changes to the `agixt/endpoints/GQL.py` file to modify the `get_user_from_context` function calls. The changes ensure that additional variables `auth` and `magical` are retrieved along with the `user`.

Key changes include:

* Updated `providers` method to retrieve `auth` and `magical` from `get_user_from_context` function.
* Updated `extension_settings` method to retrieve `auth` and `magical` from `get_user_from_context` function.
* Updated `chains` method to retrieve `auth` and `magical` from `get_user_from_context` function.
* Updated `chain_args` method to retrieve `auth` and `magical` from `get_user_from_context` function.