### PR TITLE
Fix #1370: Implement IDs for Chains in GQL

### DIFF
--- a/agixt/Chain.py
+++ b/agixt/Chain.py
@@ -135,6 +135,7 @@ class Chain:
         for chain in chains:
             chain_list.append(
                 {
+                    "id": str(chain.id),
                     "name": chain.name,
                     "description": chain.description,
                     "steps": chain.steps,


### PR DESCRIPTION
Fix #1370: Implement IDs for Chains in GQL

This pull request includes a small change to the `agixt/Chain.py` file. The change adds the `id` field to the dictionary being appended to the `chain_list` in the `get_user_chains` method.

* [`agixt/Chain.py`](diffhunk://#diff-bbe0ac321f660f213836db675911928e8a1db165b12d6cbaceb2eae96f8ab160R138): Added the `id` field to the dictionary in the `get_user_chains` method.