### PR TITLE
fix: evaluate Outlook timezone in headers

### DIFF
--- a/agixt/extensions/microsoft.py
+++ b/agixt/extensions/microsoft.py
@@ -900,7 +900,7 @@ class microsoft(Extensions):
             headers = {
                 "Authorization": f"Bearer {self.access_token}",
                 "Content-Type": "application/json",
-                "Prefer": 'outlook.timezone="{self.timezone}"',
+                "Prefer": f'outlook.timezone="{self.timezone}"',
             }
 
             response = requests.post(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Small PR - evaluates the Outlook timezone in headers dict.

## Motivation and Context

## How has this been tested?


## Screenshots (if appropriate)

## Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] My change works!
