### PR TITLE
Add Extension Command Bulk Toggle Endpoint

### DIFF
--- a/agixt/Models.py
+++ b/agixt/Models.py
@@ -191,6 +191,11 @@ class ToggleCommandPayload(BaseModel):
     enable: bool
 
 
+class ToggleExtensionCommandsPayload(BaseModel):
+    extension_name: str
+    enable: bool
+
+
 # AI Service Models
 class ChatCompletions(BaseModel):
     model: Optional[str] = None  # This is the agent name


### PR DESCRIPTION
# Add Extension Command Bulk Toggle Endpoint

## Summary

This PR adds a new endpoint that enables or disables all commands for a specific extension for a specific agent with a single API call, providing convenient bulk operations for extension management.

## Changes Made

### 1. New Model (`Models.py`)
- Added `ToggleExtensionCommandsPayload` model with:
  - `extension_name: str` - The name of the extension to toggle
  - `enable: bool` - Whether to enable or disable all commands

### 2. New V1 API Endpoint (`endpoints/Agent.py`)
- **Route**: `PATCH /v1/agent/{agent_id}/extension/commands`
- **Purpose**: Toggle all commands for a specific extension using agent ID
- **Authentication**: Requires admin privileges
- **Request Body**:
  ```json
  {
    "extension_name": "websearch",
    "enable": true
  }
  ```
- **Response**: Returns success message with count of affected commands
- **Error Handling**: Returns 404 if extension not found or has no commands

## Implementation Details

The endpoint works by:
1. Validating admin access and agent existence
2. Retrieving all extensions for the agent using existing `agent.get_agent_extensions()` method
3. Finding the specified extension and collecting all its command names
4. Creating a bulk configuration update for all commands with the specified enable/disable state
5. Applying the update using existing `agent.update_agent_config()` method
6. Returning a descriptive message with operation results

## Usage Examples

### Enable all websearch commands
```bash
curl -X PATCH "http://localhost:7437/v1/agent/12345/extension/commands" \
  -H "Authorization: your_api_key" \
  -H "Content-Type: application/json" \
  -d '{
    "extension_name": "websearch",
    "enable": true
  }'
```

**Response:**
```json
{
  "message": "Successfully enabled 5 commands for extension 'websearch'"
}
```

### Disable all file operation commands
```bash
curl -X PATCH "http://localhost:7437/v1/agent/12345/extension/commands" \
  -H "Authorization: your_api_key" \
  -H "Content-Type: application/json" \
  -d '{
    "extension_name": "file_operations",
    "enable": false
  }'
```

**Response:**
```json
{
  "message": "Successfully disabled 3 commands for extension 'file_operations'"
}
```

## Benefits

1. **Convenience**: Enable/disable all commands for an extension with one API call instead of multiple individual calls
2. **Efficiency**: Reduces API calls needed for bulk operations
3. **User Experience**: Simplifies agent configuration and template setup
4. **Consistency**: Follows existing API patterns and naming conventions
5. **Security**: Maintains admin-only access requirement for command configuration

## Use Cases

- **Agent Template Setup**: Quickly enable required extensions when creating agents from templates
- **Security Hardening**: Rapidly disable potentially dangerous extensions for production agents
- **Environment Configuration**: Enable different extension sets based on deployment environment
- **Bulk Management**: Efficiently manage extension states across multiple agents

## Backward Compatibility

- This is a new endpoint that doesn't modify existing functionality
- Existing individual command toggle endpoints remain unchanged
- Uses existing internal methods ensuring consistency with current behavior
- No breaking changes to current API structure

## Testing

The implementation leverages existing, tested functionality:
- `agent.get_agent_extensions()` for extension discovery
- `agent.update_agent_config()` for configuration updates
- Existing validation and error handling patterns

## Files Modified

1. `Models.py` - Added new `ToggleExtensionCommandsPayload` model
2. `endpoints/Agent.py` - Added new bulk toggle endpoint and imported new model