### PR TITLE
Improve inference config

### DIFF
--- a/agixt/providers/anthropic.py
+++ b/agixt/providers/anthropic.py
@@ -48,7 +48,9 @@ class AnthropicProvider:
     def services():
         return ["llm", "vision"]
 
-    async def inference(self, prompt, tokens: int = 0, images: list = []):
+    async def inference(
+        self, prompt, tokens: int = 0, images: list = [], use_smartest: bool = False
+    ):
         if (
             self.ANTHROPIC_API_KEY == ""
             or self.ANTHROPIC_API_KEY == "YOUR_ANTHROPIC_API_KEY"

--- a/agixt/providers/azure.py
+++ b/agixt/providers/azure.py
@@ -41,7 +41,12 @@ class AzureProvider:
         return ["llm", "vision"]
 
     async def inference(
-        self, prompt, tokens: int = 0, images: list = [], stream: bool = False
+        self,
+        prompt,
+        tokens: int = 0,
+        images: list = [],
+        stream: bool = False,
+        use_smartest: bool = False,
     ):
         if not self.AZURE_OPENAI_ENDPOINT.endswith("/"):
             self.AZURE_OPENAI_ENDPOINT += "/"

--- a/agixt/providers/azure_foundry.py
+++ b/agixt/providers/azure_foundry.py
@@ -49,7 +49,9 @@ class Azure_foundryProvider:
     def services():
         return ["llm", "vision"]
 
-    async def inference(self, prompt, tokens: int = 0, images: list = []):
+    async def inference(
+        self, prompt, tokens: int = 0, images: list = [], use_smartest: bool = False
+    ):
         if self.AZURE_API_KEY == "" or self.AZURE_API_KEY == "YOUR_API_KEY":
             return "Please go to the Agent Management page to set your Azure AI Inference API key."
 

--- a/agixt/providers/chutes.py
+++ b/agixt/providers/chutes.py
@@ -79,14 +79,14 @@ class ChutesProvider:
         tokens: int = 0,
         images: list = [],
         stream: bool = False,
-        code: bool = False,
+        use_smartest: bool = False,
     ):
         if not self.ENDPOINT_URL:
             return "Please configure the Chutes endpoint URL (e.g., https://myuser-my-llm.chutes.ai) in the Agent Management page."
 
         if self.API_KEY == "" or self.API_KEY == "YOUR_CHUTES_API_KEY":
             return "Please go to the Agent Management page to set your Chutes API key."
-        if code:
+        if use_smartest:
             self.AI_MODEL = self.CHUTES_CODING_MODEL
         if len(images) > 0:
             self.AI_MODEL = self.CHUTES_VISION_MODEL
@@ -217,7 +217,7 @@ class ChutesProvider:
                     tokens=tokens,
                     images=images,
                     stream=stream,
-                    code=code,
+                    use_smartest=use_smartest,
                 )
 
             return f"Error calling Chutes API: {str(e)}"

--- a/agixt/providers/deepseek.py
+++ b/agixt/providers/deepseek.py
@@ -56,7 +56,9 @@ class DeepseekProvider:
             "vision",
         ]
 
-    async def inference(self, prompt, tokens: int = 0, images: list = []):
+    async def inference(
+        self, prompt, tokens: int = 0, images: list = [], use_smartest: bool = False
+    ):
         openai.base_url = self.API_URI if self.API_URI else "https://api.deepseek.com/"
         openai.api_key = self.DEEPSEEK_API_KEY
         openai.api_type = "openai"

--- a/agixt/providers/default.py
+++ b/agixt/providers/default.py
@@ -87,7 +87,9 @@ class DefaultProvider:
             "translation",
         ]
 
-    async def inference(self, prompt, tokens: int = 0, images: list = []):
+    async def inference(
+        self, prompt, tokens: int = 0, images: list = [], use_smartest: bool = False
+    ):
         return await Gpt4freeProvider(
             **self.agent_settings,
         ).inference(prompt=prompt, tokens=tokens, images=images)

--- a/agixt/providers/ezlocalai.py
+++ b/agixt/providers/ezlocalai.py
@@ -86,7 +86,12 @@ class EzlocalaiProvider:
                 break
 
     async def inference(
-        self, prompt, tokens: int = 0, images: list = [], stream: bool = False
+        self,
+        prompt,
+        tokens: int = 0,
+        images: list = [],
+        stream: bool = False,
+        use_smartest: bool = False,
     ):
         if not self.AI_MODEL:
             self.AI_MODEL = "default"

--- a/agixt/providers/google.py
+++ b/agixt/providers/google.py
@@ -50,7 +50,9 @@ class GoogleProvider:
     def services():
         return ["llm", "tts", "vision"]
 
-    async def inference(self, prompt, tokens: int = 0, images: list = []):
+    async def inference(
+        self, prompt, tokens: int = 0, images: list = [], use_smartest: bool = False
+    ):
         if not self.GOOGLE_API_KEY or self.GOOGLE_API_KEY == "None":
             return "Please set your Google API key in the Agent Management page."
         try:

--- a/agixt/providers/gpt4free.py
+++ b/agixt/providers/gpt4free.py
@@ -59,7 +59,9 @@ class Gpt4freeProvider:
     def services():
         return ["llm"]
 
-    async def inference(self, prompt, tokens: int = 0, images: list = []):
+    async def inference(
+        self, prompt, tokens: int = 0, images: list = [], use_smartest: bool = False
+    ):
         agent_settings = {
             k: v for k, v in self.agent_settings.items() if v is not None and v != ""
         }

--- a/agixt/providers/huggingface.py
+++ b/agixt/providers/huggingface.py
@@ -53,7 +53,9 @@ class HuggingfaceProvider:
     def services():
         return ["llm", "image"]
 
-    async def inference(self, prompt, tokens: int = 0, images: list = []):
+    async def inference(
+        self, prompt, tokens: int = 0, images: list = [], use_smartest: bool = False
+    ):
         payload = {
             "inputs": prompt,
             "parameters": {

--- a/agixt/providers/openai.py
+++ b/agixt/providers/openai.py
@@ -27,6 +27,8 @@ class OpenaiProvider:
         self,
         OPENAI_API_KEY: str = "",
         OPENAI_MODEL: str = "gpt-4o",
+        OPENAI_VISION_MODEL: str = "gpt-4o",
+        OPENAI_CODING_MODEL: str = "gpt-5",
         OPENAI_API_URI: str = "https://api.openai.com/v1",
         OPENAI_MAX_TOKENS: int = 128000,
         OPENAI_TEMPERATURE: float = 0.7,
@@ -39,6 +41,12 @@ class OpenaiProvider:
     ):
         self.requirements = ["openai"]
         self.AI_MODEL = OPENAI_MODEL if OPENAI_MODEL else "gpt-4o"
+        self.OPENAI_VISION_MODEL = (
+            OPENAI_VISION_MODEL if OPENAI_VISION_MODEL else "gpt-4o"
+        )
+        self.OPENAI_CODING_MODEL = (
+            OPENAI_CODING_MODEL if OPENAI_CODING_MODEL else "gpt-5"
+        )
         self.AI_TEMPERATURE = OPENAI_TEMPERATURE if OPENAI_TEMPERATURE else 0.7
         self.AI_TOP_P = OPENAI_TOP_P if OPENAI_TOP_P else 0.7
         self.MAX_TOKENS = OPENAI_MAX_TOKENS if OPENAI_MAX_TOKENS else 128000
@@ -84,11 +92,17 @@ class OpenaiProvider:
                 break
 
     async def inference(
-        self, prompt, tokens: int = 0, images: list = [], stream: bool = False
+        self,
+        prompt,
+        tokens: int = 0,
+        images: list = [],
+        stream: bool = False,
+        use_smartest: bool = False,
     ):
-        if images != []:
-            if "vision" not in self.AI_MODEL and self.AI_MODEL != "gpt-4o":
-                self.AI_MODEL = "gpt-4o"
+        if use_smartest:
+            self.AI_MODEL = self.OPENAI_CODING_MODEL
+        if len(images) > 0:
+            self.AI_MODEL = self.OPENAI_VISION_MODEL
         if not self.API_URI.endswith("/"):
             self.API_URI += "/"
         openai.base_url = self.API_URI if self.API_URI else "https://api.openai.com/v1/"

--- a/agixt/providers/rotation.py
+++ b/agixt/providers/rotation.py
@@ -177,7 +177,7 @@ class RotationProvider:
                 **self.AGENT_SETTINGS,
             )
             result = await provider_instance.inference(
-                prompt=prompt, tokens=tokens, images=images
+                prompt=prompt, tokens=tokens, images=images, use_smartest=use_smartest
             )
             if isinstance(result, str) and result.startswith("Error:"):
                 raise Exception(f"Provider {provider} returned an error: {result}")

--- a/agixt/providers/xai.py
+++ b/agixt/providers/xai.py
@@ -55,7 +55,9 @@ class XaiProvider:
             "vision",
         ]
 
-    async def inference(self, prompt, tokens: int = 0, images: list = []):
+    async def inference(
+        self, prompt, tokens: int = 0, images: list = [], use_smartest: bool = False
+    ):
         openai.base_url = self.API_URI if self.API_URI else "https://api.x.ai/v1/"
         openai.api_key = f"Bearer {self.XAI_API_KEY}"
         openai.api_type = "openai"


### PR DESCRIPTION
Improve inference config
- Added `use_smartest` arg to each provider to have coding requests routed to coding models.
- Set `rotation` as the default vision provider to avoid denied requests where vision is not configured.
- Added multi-model config to OpenAI provider