### PR TITLE
Fix Command Duplication

### DIFF
--- a/agixt/Interactions.py
+++ b/agixt/Interactions.py
@@ -327,6 +327,11 @@ class Interactions:
             context.append(
                 f"## Persona\n**The assistant follows a persona and uses the following guidelines and information to remain in character.**\n{persona}\nThe assistant is {self.agent_name} and is an AGiXT agent created by DevXT, empowered with AGiXT abilities."
             )
+        APP_URI = getenv("APP_URI")
+        if "localhost:" not in APP_URI:
+            context.append(
+                f"The assistant is an AGiXT agent named `{self.agent_name}` running on {APP_URI}. The assistant can access the documentation about the website at {AGIXT_URI}/docs as well as information about the open source AGiXT back end repository at https://github.com/Josh-XT/AGiXT if necessary."
+            )
         if "72" in kwargs and "42" in kwargs:
             if kwargs["72"] == True and kwargs["42"] == True:
                 kwargs["fp"] = context


### PR DESCRIPTION
# Fix Command Duplication and Enable Graceful Command Migration Between Extensions

## Problem

When extension commands were moved from one extension to another, the seeding process would create duplicate `Command` records in the database instead of migrating the existing record. This caused issues when trying to enable commands by name:

- Multiple database rows existed for the same command name
- Agent command references pointed to different command IDs
- Command enabling operations could fail silently or enable the wrong record
- Chain steps, arguments, and agent commands became orphaned or duplicated

## Solution

### 1. Enhanced SeedImports.py

**Added duplicate detection and merging logic:**

- Built a `command_owner_map` at the start of `import_extensions()` to track which extension owns each command according to the current codebase
- Created `_merge_command_duplicates()` helper function to consolidate duplicate command records:
  - Migrates all `AgentCommand` associations to the canonical record
  - Moves `Argument` records to the canonical command
  - Updates `ChainStep` references that target duplicate commands
  - Preserves enabled state (if any duplicate was enabled, the merged record stays enabled)
  - Deletes the duplicate command records

**Improved command processing during import:**

- Detect when a command exists in multiple extensions and determine if it's truly shared or has been moved
- When a command has moved extensions, relocate the existing `Command` record instead of creating a duplicate
- Log command moves for visibility: `"Moving command 'X' from extension 'Y' to 'Z'"`
- Merge any remaining duplicates found during processing

### 2. Enhanced Agent.py

**Added deterministic command resolution:**

- Created `_get_command_owner_cache()` to cache the extension-to-command relationship at runtime
- Implemented `_resolve_command_by_name()` helper that:
  - Returns `None` if no command exists
  - Returns the single match if only one exists
  - When duplicates exist, prefers the command from the extension listed in the owner cache
  - Falls back to the first match with a warning if cache lookup fails

**Updated command lookups:**

- Replaced direct `session.query(Command).filter_by(name=...)` calls with `_resolve_command_by_name()` in:
  - `add_agent()` - when processing the `commands` parameter
  - `Agent.update_agent_config()` - when updating agent command settings

## Benefits

- **Graceful migration**: Commands can be moved between extensions without creating duplicates
- **Backward compatibility**: Existing duplicate records are automatically merged during import
- **Deterministic behavior**: Command resolution always picks the canonical record
- **Data integrity**: Agent commands, arguments, and chain steps remain linked correctly
- **Better logging**: Command moves are now logged for debugging

## Technical Details

**Files Modified:**

- `agixt/SeedImports.py`: Added duplicate merging logic and improved command import flow
- `agixt/Agent.py`: Added command resolution helper and replaced direct lookups

**Database Impact:**

- Existing duplicate `Command` records will be merged on next import
- `AgentCommand`, `Argument`, and `ChainStep` references will be consolidated
- No schema changes required
