### PR TITLE
Add agent cloning and sharing

### DIFF
--- a/agixt/Agent.py
+++ b/agixt/Agent.py
@@ -147,6 +147,53 @@ def impersonate_user(user_id: str):
     return token
 
 
+def can_user_access_agent(user_id, agent_id, auth: MagicalAuth = None):
+    """
+    Check if a user can access an agent.
+    Returns: (can_access: bool, is_owner: bool, access_level: str)
+    """
+    session = get_session()
+
+    # Get the agent
+    agent = session.query(AgentModel).filter(AgentModel.id == agent_id).first()
+    if not agent:
+        session.close()
+        return (False, False, None)
+
+    # User is owner
+    if str(agent.user_id) == str(user_id):
+        session.close()
+        return (True, True, "owner")
+
+    # Check if shared and user is in same company
+    agent_settings = (
+        session.query(AgentSettingModel)
+        .filter(AgentSettingModel.agent_id == agent_id)
+        .all()
+    )
+
+    settings_dict = {s.name: s.value for s in agent_settings}
+    is_shared = settings_dict.get("shared", "false") == "true"
+    agent_company_id = settings_dict.get("company_id")
+
+    if not is_shared or not agent_company_id:
+        session.close()
+        return (False, False, None)
+
+    # Use MagicalAuth helper to get user's companies
+    if not auth:
+        token = impersonate_user(user_id=str(user_id))
+        auth = MagicalAuth(token=token)
+
+    user_company_ids = auth.get_user_companies()
+
+    # Check if agent's company is in user's companies
+    has_access = agent_company_id in user_company_ids
+    session.close()
+
+    return (has_access, False, "viewer" if has_access else None)
+
+
 def add_agent(agent_name, provider_settings=None, commands=None, user=DEFAULT_USER):
     if not agent_name:
         return {"message": "Agent name cannot be empty."}
@@ -510,21 +557,56 @@ def get_agents(user=DEFAULT_USER, company=None):
         )
     except:
         default_agent_id = ""
-    agents = session.query(AgentModel).filter(AgentModel.user_id == user_data.id).all()
+
+    # Get user's companies using MagicalAuth
+    token = impersonate_user(user_id=str(user_data.id))
+    auth = MagicalAuth(token=token)
+    user_company_ids = auth.get_user_companies()
+
+    # Query owned agents
+    owned_agents = (
+        session.query(AgentModel).filter(AgentModel.user_id == user_data.id).all()
+    )
+
+    # Query shared agents if user has companies
+    shared_agents = []
+    if user_company_ids:
+        # Get all agents that are not owned by this user
+        potential_shared = (
+            session.query(AgentModel).filter(AgentModel.user_id != user_data.id).all()
+        )
+
+        for agent in potential_shared:
+            settings = (
+                session.query(AgentSettingModel)
+                .filter(AgentSettingModel.agent_id == agent.id)
+                .all()
+            )
+            settings_dict = {s.name: s.value for s in settings}
+
+            is_shared = settings_dict.get("shared", "false") == "true"
+            agent_company_id = settings_dict.get("company_id")
+
+            if is_shared and agent_company_id in user_company_ids:
+                shared_agents.append(agent)
+
+    # Combine owned and shared agents
+    all_agents = owned_agents + shared_agents
+
     if default_agent_id == "":
         # Add a user preference of the first agent's ID in the agent list
-        if agents:
+        if all_agents:
             user_preference = UserPreferences(
-                user_id=user_data.id, pref_key="agent_id", pref_value=agents[0].id
+                user_id=user_data.id, pref_key="agent_id", pref_value=all_agents[0].id
             )
             session.add(user_preference)
             session.commit()
-            default_agent_id = str(agents[0].id)
+            default_agent_id = str(all_agents[0].id)
         else:
             session.close()
             return []
     output = []
-    for agent in agents:
+    for agent in all_agents:
         # Check if the agent is in the output already
         if agent.name in [a["name"] for a in output]:
             continue
@@ -601,6 +683,9 @@ def get_agents(user=DEFAULT_USER, company=None):
             )
             session.add(agent_setting)
             session.commit()
+        is_owner = agent.user_id == user_data.id
+        is_shared = settings_dict.get("shared", "false") == "true"
+
         output.append(
             {
                 "name": agent.name,
@@ -608,10 +693,73 @@ def get_agents(user=DEFAULT_USER, company=None):
                 "status": False,
                 "company_id": company_id,
                 "default": str(agent.id) == str(default_agent_id),
+                "is_owner": is_owner,
+                "is_shared": is_shared,
+                "access_level": "owner" if is_owner else "viewer",
             }
         )
     session.close()
     return output
+
+
+def clone_agent(agent_id, new_agent_name, user=DEFAULT_USER):
+    """
+    Clone an agent, copying all settings and commands.
+    User must have access to the source agent.
+    """
+    session = get_session()
+    user_data = session.query(User).filter(User.email == user).first()
+
+    # Check access to source agent
+    can_access, is_owner, access_level = can_user_access_agent(
+        user_id=user_data.id, agent_id=agent_id
+    )
+
+    if not can_access:
+        session.close()
+        raise HTTPException(status_code=403, detail="No access to source agent")
+
+    # Get source agent
+    source_agent = session.query(AgentModel).filter(AgentModel.id == agent_id).first()
+
+    if not source_agent:
+        session.close()
+        raise HTTPException(status_code=404, detail="Source agent not found")
+
+    # Get source agent settings
+    source_settings = (
+        session.query(AgentSettingModel)
+        .filter(AgentSettingModel.agent_id == agent_id)
+        .all()
+    )
+
+    settings_dict = {s.name: s.value for s in source_settings}
+
+    # Remove shared flag - cloned agents are private by default
+    settings_dict.pop("shared", None)
+
+    # Get source agent commands
+    source_commands = (
+        session.query(AgentCommand).filter(AgentCommand.agent_id == agent_id).all()
+    )
+
+    commands_dict = {}
+    for ac in source_commands:
+        command = session.query(Command).filter(Command.id == ac.command_id).first()
+        if command:
+            commands_dict[command.name] = ac.state
+
+    session.close()
+
+    # Create new agent using existing add_agent function
+    result = add_agent(
+        agent_name=new_agent_name,
+        provider_settings=settings_dict,
+        commands=commands_dict,
+        user=user,
+    )
+
+    return result
 
 
 class Agent:

--- a/agixt/endpoints/Agent.py
+++ b/agixt/endpoints/Agent.py
@@ -14,6 +14,7 @@ from ApiClient import (
     get_api_client,
     is_admin,
 )
+from Agent import can_user_access_agent, clone_agent as clone_agent_func
 from Models import (
     AgentNewName,
     AgentPrompt,
@@ -108,7 +109,8 @@ async def think(
     else:
         agent_prompt.prompt_args["context"] = think_deep
     agent_prompt.prompt_args["user_input"] = agent_prompt.user_input
-    return await prompt_agent(
+    ApiClient = get_api_client(authorization=authorization)
+    return ApiClient.prompt_agent(
         agent_name=agent_prompt.agent_name,
         agent_prompt=AgentPrompt(
             prompt_name="Think About It",
@@ -807,3 +809,38 @@ async def get_agent_wallet_v1(
         private_key=wallet_info["private_key"],
         passphrase=wallet_info["passphrase"],
     )
+
+
+@app.post(
+    "/v1/agent/{agent_id}/clone",
+    tags=["Agent"],
+    dependencies=[Depends(verify_api_key)],
+    summary="Clone an agent by ID",
+    description="Creates a copy of an agent with all its settings and commands. User must have access to the source agent. The cloned agent is private by default (shared flag is removed).",
+    response_model=ResponseMessage,
+)
+async def clone_agent_v1(
+    agent_id: str,
+    new_name: AgentNewName,
+    user=Depends(verify_api_key),
+    authorization: str = Header(None),
+) -> ResponseMessage:
+    # Get user_id from auth
+    auth = MagicalAuth(token=authorization)
+
+    # Check if user has access to the agent
+    can_access, is_owner, access_level = can_user_access_agent(
+        user_id=auth.user_id, agent_id=agent_id
+    )
+
+    if not can_access:
+        raise HTTPException(
+            status_code=403, detail="You do not have access to this agent"
+        )
+
+    # Clone the agent
+    result = clone_agent_func(
+        agent_id=agent_id, new_agent_name=new_name.new_name, user=user
+    )
+
+    return ResponseMessage(message=result.get("message", "Agent cloned successfully"))


### PR DESCRIPTION
This pull request introduces agent sharing and cloning features, enhancing agent accessibility and management. The changes allow users to access agents shared within their company and provide a new API endpoint to clone agents, ensuring that cloned agents are private by default. The agent listing is updated to show both owned and shared agents, with clear access levels.

**Agent sharing and access control:**
* Added `can_user_access_agent` function to determine if a user can access an agent, considering ownership and company-based sharing.
* Updated `get_agents` to include both owned and shared agents for a user, based on company membership, and added `is_owner`, `is_shared`, and `access_level` fields to agent data. [[1]](diffhunk://#diff-556d8be092ab95b9c185df744d2b3c8f7ad8652b5819506599877fd2a9cead8dL513-R609) [[2]](diffhunk://#diff-556d8be092ab95b9c185df744d2b3c8f7ad8652b5819506599877fd2a9cead8dR686-R764)

**Agent cloning functionality:**
* Added `clone_agent` function to allow users with access to clone an agent, copying its settings and commands, and ensuring the cloned agent is private (removes shared flag).
* Introduced `/v1/agent/{agent_id}/clone` API endpoint for agent cloning, with access checks and response handling.
* Imported new helper functions in the API module and updated prompt handling to use the API client directly. [[1]](diffhunk://#diff-63996219a9a8302ec8c143a8f90d35f2f2bb44a8a15bb2d156c698f9b30151acR17) [[2]](diffhunk://#diff-63996219a9a8302ec8c143a8f90d35f2f2bb44a8a15bb2d156c698f9b30151acL111-R113)