### PR TITLE
Potential fix for code scanning alert no. 340: Information exposure through an exception

### DIFF
--- a/agixt/XT.py
+++ b/agixt/XT.py
@@ -2925,7 +2925,7 @@ Your response (true or false):"""
                 "choices": [
                     {
                         "index": 0,
-                        "delta": {"content": f"Error: {str(e)}"},
+                        "delta": {"content": "Error: An internal error has occurred."},
                         "finish_reason": "stop",
                     }
                 ],


### PR DESCRIPTION
Potential fix for [https://github.com/Josh-XT/AGiXT/security/code-scanning/340](https://github.com/Josh-XT/AGiXT/security/code-scanning/340)

To fix this information exposure, update the relevant error handler in `agixt/XT.py` where `str(e)` is placed directly inside the chunk content (lines 2914–2933). Change it so the client receives a generic error message, e.g., `"An internal error has occurred."`, while the actual error details continue to be logged for diagnosis.  
Only replace the user-facing content inside `error_chunk` with a generic message, leaving logging and all other server-side behavior unchanged.  
No new methods are needed, though the patch should ensure ample logging for developer diagnosis (which the code already provides).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
