### PR TITLE
Potential fix for code scanning alert no. 431: Information exposure through an exception

### DIFF
--- a/agixt/MagicalAuth.py
+++ b/agixt/MagicalAuth.py
@@ -6983,10 +6983,12 @@ def validate_personal_access_token(token: str) -> dict:
             "token_name": pat.name,
         }
     except Exception as e:
+        # Log full error details on the server, but do not expose them to the caller
         logging.error(f"Error validating personal access token: {str(e)}")
         return {
             "valid": False,
-            "error": f"Validation error: {str(e)}",
+            # Return a generic error message to avoid leaking internal details
+            "error": "Internal validation error",
         }
     finally:
         session.close()

--- a/agixt/endpoints/ApiKey.py
+++ b/agixt/endpoints/ApiKey.py
@@ -237,9 +237,8 @@ async def validate_api_key_endpoint(
     """
     result = validate_personal_access_token(token)
     if not result["valid"]:
-        raise HTTPException(
-            status_code=401, detail=result.get("error", "Invalid token")
-        )
+        # Do not expose internal validation error details to the client
+        raise HTTPException(status_code=401, detail="Invalid token")
 
     # Don't return all details for security - just confirm validity
     return {


### PR DESCRIPTION
Potential fix for [https://github.com/Josh-XT/AGiXT/security/code-scanning/431](https://github.com/Josh-XT/AGiXT/security/code-scanning/431)

In general, the fix is to ensure that low-level exception messages are not sent back to clients. Instead, exceptions should be logged on the server and a generic, non-sensitive error message should be returned.

The single best way to fix this without changing existing functionality is:

1. In `MagicalAuth.validate_personal_access_token`, keep logging the detailed exception on the server, but replace the client-facing `"error"` value in the exception case with a generic message (for example, `"Internal validation error"`). This prevents leaking details while preserving the same shape of the returned dict (`{"valid": False, "error": ...}`), so existing callers keep working.

2. Optionally, to further harden the API layer, normalize the error returned by `validate_api_key_endpoint` so that any failure (including this generic error) is mapped to a fixed, non-detailed message like `"Invalid token"`. This keeps behavior largely the same (401 on invalid tokens) but avoids exposing even internal error labels.

Concretely:

- Edit `agixt/MagicalAuth.py` around lines 6985–6990 to change:
  - The logged message can keep using `str(e)` (server-side only).
  - The dict returned in the `except` block should use a generic, non-detailed string for `"error"` instead of `f"Validation error: {str(e)}"`.

- Optionally (but recommended), edit `agixt/endpoints/ApiKey.py` in `validate_api_key_endpoint` so that when `not result["valid"]`, the `HTTPException` uses a constant message like `"Invalid token"` rather than `result.get("error", "Invalid token")`.

No new methods are required; we only adjust the returned error string and, optionally, the endpoint’s error mapping. No extra imports are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
