### PR TITLE
Potential fix for code scanning alert no. 432: Information exposure through an exception

### DIFF
--- a/agixt/ResponseCache.py
+++ b/agixt/ResponseCache.py
@@ -421,6 +421,7 @@ class ResponseCacheManager:
             }
 
         except Exception as e:
+            # Log detailed error server-side, but do not expose exception details to clients
             logger.warning(f"Cache stats error: {e}")
             return {
                 "hits": self._stats["hits"],
@@ -429,7 +430,7 @@ class ResponseCacheManager:
                 "invalidations": self._stats["invalidations"],
                 "errors": self._stats["errors"],
                 "storage": "unknown",
-                "error": str(e),
+                "error": "internal error while retrieving cache statistics",
             }
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/Josh-XT/AGiXT/security/code-scanning/432](https://github.com/Josh-XT/AGiXT/security/code-scanning/432)

To fix the problem, we need to ensure that internal exception details from the cache layer are not returned to the API client. Instead, we should log the detailed error on the server and send back a generic, non-sensitive message in the JSON response.

The best minimal fix, without changing functionality of successful calls, is to modify the `except` block in `ResponseCacheManager.get_stats` so that it no longer includes `str(e)` in the returned dict. We will keep logging `e` for debugging, but the returned structure should only contain generic, non-sensitive fields (e.g., a boolean `error` flag or a generic string such as `"internal error"`). Since the API endpoint in `agixt/app.py` already wraps the call in a `try/except` and returns a generic HTTP 500 message on errors, returning a simplified, non-detailed stats payload on internal errors is acceptable and keeps behavior largely intact (clients still receive a JSON object, just without sensitive details).

Concretely:
- In `agixt/ResponseCache.py`, adjust the `get_stats` method’s `except` block to:
  - Keep the `logger.warning(f"Cache stats error: {e}")` logging.
  - Return a dict that does not contain `str(e)` or any other direct exception message. For example, replace `"error": str(e)` with something like `"error": "internal error"` or a boolean flag.
- No changes are needed in `agixt/app.py` for this specific issue, since it already returns a generic HTTPException message.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
