### PR TITLE
Potential fix for code scanning alert no. 413: Uncontrolled data used in path expression

### DIFF
--- a/agixt/XT.py
+++ b/agixt/XT.py
@@ -2592,14 +2592,24 @@ Your response (true or false):"""
                                                     file_name,
                                                 )
                                             )
+                                            # Ensure the final path stays within the agent workspace
+                                            workspace_root = os.path.abspath(self.agent_workspace)
+                                            abs_file_path = os.path.abspath(file_path)
+                                            if os.path.commonpath(
+                                                [workspace_root, abs_file_path]
+                                            ) != workspace_root:
+                                                logging.error(
+                                                    f"[chat_completions] Refusing to write repo ZIP outside workspace: {abs_file_path}"
+                                                )
+                                                continue
                                             os.makedirs(
-                                                os.path.dirname(file_path),
+                                                os.path.dirname(abs_file_path),
                                                 exist_ok=True,
                                             )
-                                            with open(file_path, "wb") as f:
+                                            with open(abs_file_path, "wb") as f:
                                                 f.write(response.content)
                                             logging.info(
-                                                f"[chat_completions] Downloaded GitHub repo to: {file_path}"
+                                                f"[chat_completions] Downloaded GitHub repo to: {abs_file_path}"
                                             )
                                             # Append as dict with file_name and file_url for consistency
                                             file_url = f"{self.outputs}/{conversation_id}/{file_name}"


### PR DESCRIPTION
Potential fix for [https://github.com/Josh-XT/AGiXT/security/code-scanning/413](https://github.com/Josh-XT/AGiXT/security/code-scanning/413)

In general, to fix this kind of issue you must ensure that any filesystem path derived from untrusted input is both normalized and verified to remain under an intended root directory before creating directories or reading/writing files. Normalization with `os.path.normpath` or `os.path.realpath` alone is not sufficient; you must also enforce that the result starts with (or is otherwise constrained to) a safe base path.

For this specific case, the path in question is:

```python
file_path = os.path.normpath(
    os.path.join(
        self.agent_workspace,
        conversation_id,
        file_name,
    )
)
os.makedirs(os.path.dirname(file_path), exist_ok=True)
with open(file_path, "wb") as f:
    f.write(response.content)
```

The best targeted fix without changing existing functionality is:

1. Define a clear, trusted base directory for these downloads. The natural choice is `self.agent_workspace`, which appears to be the agent’s configured workspace directory.
2. After building `file_path` with `os.path.normpath`, validate that it remains inside `self.agent_workspace`. A portable way to do this is to compute normalized absolute paths for both `self.agent_workspace` and `file_path`, then check with `os.path.commonpath` that the workspace directory is a prefix of the resulting path.
3. If the check fails, log an error and skip writing the file (or raise an exception). This prevents directory traversal or escape outside the workspace even if `conversation_id` or `file_name` are manipulated.
4. Only call `os.makedirs` and `open` if the path passes this validation.

No new imports are required; `os.path.commonpath` and `os.path.abspath` are available in the already-imported `os` module.

Concretely, inside `agixt/XT.py` in `_execute_chat_completions`, right after computing `file_path`, we will:

- Compute `workspace_root = os.path.abspath(self.agent_workspace)` and `abs_file_path = os.path.abspath(file_path)`.
- Check `if os.path.commonpath([workspace_root, abs_file_path]) != workspace_root:`, and if so, log an error and `continue` so that the unsafe path is never used.
- If safe, proceed with `os.makedirs(os.path.dirname(abs_file_path), exist_ok=True)` and `open(abs_file_path, "wb")`.

This single guard will address all six alert variants, since they all concern the same path sink.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
