### PR TITLE
fix: move migrate_task_item_table() outside commented block

### DIFF
--- a/agixt/run-local.py
+++ b/agixt/run-local.py
@@ -141,6 +141,11 @@ async def initialize_database(is_restart=False):
         DB.cleanup_expired_cache()
         startup_timer.section_end("cleanup_expired_cache", section_start)
 
+        # Run task item migration for new scheduled task type columns
+        section_start = startup_timer.section_start()
+        DB.migrate_task_item_table()
+        startup_timer.section_end("migrate_task_item_table", section_start)
+
         # Initialize extension tables
         section_start = startup_timer.section_start()
         DB.initialize_extension_tables()


### PR DESCRIPTION
## Problem

PR #1629 added `migrate_task_item_table()` to support new scheduled task types with the following columns:
- `task_type`
- `command_script` 
- `deployment_id`
- `target_machines`

However, the migration call was placed inside a triple-quoted string block (lines 82-137 in `run-local.py`) that serves as a commented-out section for optimization purposes. This means the migration would never actually run, preventing the new columns from being created on the `task_item` table.

## Root Cause

The commented-out migration block in `run-local.py` is wrapped in `"""..."""` to skip certain migrations during startup for performance. New migrations should be added after line 138 where the active code resumes, but PR #1629 inadvertently added it inside the commented block.

## Solution

Moved the `migrate_task_item_table()` call to the active code section after `cleanup_expired_cache()`, following the same timing/logging pattern as other active migrations:

```python
# Run task item migration for new scheduled task type columns
section_start = startup_timer.section_start()
DB.migrate_task_item_table()
startup_timer.section_end("migrate_task_item_table", section_start)
```

## Testing

1. Start AGiXT with an existing database
2. Check logs for "migrate_task_item_table" timing entry
3. Verify `task_item` table has the new columns: `task_type`, `command_script`, `deployment_id`, `target_machines`

## Related

- PR #1629 - feat: add task types (prompt/command/deployment) to scheduled tasks
