### PR TITLE
Performance improvements

### DIFF
--- a/agixt/Conversations.py
+++ b/agixt/Conversations.py
@@ -24,7 +24,7 @@ from DB import (
     DATABASE_TYPE,
 )
 from Globals import getenv, DEFAULT_USER
-from sqlalchemy.sql import func, or_, and_, case, exists
+from sqlalchemy.sql import func, or_, and_, case, exists, select
 from sqlalchemy.exc import IntegrityError
 from MagicalAuth import convert_time, get_user_id, get_user_timezone
 from SharedCache import shared_cache
@@ -1066,7 +1066,214 @@ class Conversations:
         finally:
             session.close()
 
-    def get_conversations_with_detail(self, limit=None, offset=0):
+    def get_conversation_counts(self):
+        """Cheap aggregate counts for the user's conversation list.
+
+        Returns counts that match exactly the same scope as
+        ``get_conversations_with_detail`` (excludes group/thread, keeps DM/
+        private even without messages), so frontends can show stable
+        ``X conversations`` / unread badges immediately after the first
+        paginated request — no need to wait for full hydration.
+        """
+        session = get_session()
+        user_id = self._user_id
+        if not user_id:
+            session.close()
+            return {"total": 0, "pinned": 0, "unread": 0}
+
+        try:
+            # Materialise the set of in-scope conversation IDs once, then run
+            # the aggregate counts against that list. Using `Conversation.id.in_(ids)`
+            # in subsequent queries avoids SQLAlchemy auto-correlating an
+            # ``exists()`` subquery in unexpected ways across multiple SELECTs
+            # (which produced the "returned no FROM clauses" errors).
+            participant_rows = (
+                session.query(ConversationParticipant.conversation_id)
+                .filter(
+                    ConversationParticipant.user_id == user_id,
+                    ConversationParticipant.participant_type == "user",
+                    ConversationParticipant.status == "active",
+                )
+                .all()
+            )
+            participant_conv_id_list = [str(row[0]) for row in participant_rows]
+            participant_clause = (
+                Conversation.id.in_(participant_conv_id_list)
+                if participant_conv_id_list
+                else False
+            )
+
+            # Conversation IDs that have at least one message — flat list query
+            # rather than an EXISTS in scope_filter so it doesn't get
+            # auto-correlated when reused. Bounded to user-relevant convs to
+            # avoid scanning the full Message table.
+            owned_rows = (
+                session.query(Conversation.id)
+                .filter(or_(Conversation.user_id == user_id, participant_clause))
+                .all()
+            )
+            owned_ids = [str(row[0]) for row in owned_rows]
+            convs_with_messages = set()
+            if owned_ids:
+                msg_rows = (
+                    session.query(Message.conversation_id)
+                    .filter(Message.conversation_id.in_(owned_ids))
+                    .distinct()
+                    .all()
+                )
+                convs_with_messages = {str(row[0]) for row in msg_rows}
+
+            # Final in-scope ids: owned/participant + non-group/thread + has
+            # messages OR is a DM/private (which counts even when empty).
+            in_scope_rows = (
+                session.query(
+                    Conversation.id,
+                    Conversation.conversation_type,
+                    Conversation.pin_order,
+                )
+                .filter(or_(Conversation.user_id == user_id, participant_clause))
+                .filter(
+                    or_(
+                        Conversation.conversation_type.is_(None),
+                        Conversation.conversation_type.notin_(["group", "thread"]),
+                    ),
+                )
+                .all()
+            )
+            in_scope_ids: List[str] = []
+            pinned = 0
+            for cid, ctype, pin_order in in_scope_rows:
+                cid_str = str(cid)
+                # Match the same "keep DM/private even without messages"
+                # logic used by get_conversations_with_detail.
+                if ctype in ("dm", "private") or cid_str in convs_with_messages:
+                    in_scope_ids.append(cid_str)
+                    if pin_order is not None:
+                        pinned += 1
+
+            total = len(in_scope_ids)
+
+            unread = 0
+            if in_scope_ids:
+                # Unread approximation: any conversation with a non-USER,
+                # non-activity message newer than the user's last_read_at
+                # (or no participant row at all).
+                last_read_map: Dict[str, Any] = {}
+                user_participants = (
+                    session.query(
+                        ConversationParticipant.conversation_id,
+                        ConversationParticipant.last_read_at,
+                    )
+                    .filter(
+                        ConversationParticipant.conversation_id.in_(in_scope_ids),
+                        ConversationParticipant.user_id == user_id,
+                        ConversationParticipant.participant_type == "user",
+                    )
+                    .all()
+                )
+                for cid_val, last_read in user_participants:
+                    last_read_map[str(cid_val)] = last_read
+
+                # Ask the DB for each conversation's most-recent agent-message
+                # timestamp in one query.
+                latest_msgs = (
+                    session.query(
+                        Message.conversation_id,
+                        func.max(Message.timestamp).label("ts"),
+                    )
+                    .filter(
+                        Message.conversation_id.in_(in_scope_ids),
+                        Message.role != "USER",
+                        ~Message.content.like("[ACTIVITY]%"),
+                        ~Message.content.like("[SUBACTIVITY]%"),
+                    )
+                    .group_by(Message.conversation_id)
+                    .all()
+                )
+                for cid_val, ts in latest_msgs:
+                    if ts is None:
+                        continue
+                    last_read = last_read_map.get(str(cid_val))
+                    if last_read is None or ts > last_read:
+                        unread += 1
+
+            # Per-agent counts. Mirrors the agent-role resolution pattern
+            # used by get_conversations_with_detail: the "agent" for a
+            # conversation is the role string of its first non-USER, non-
+            # activity message. Default agent for the user fills in for
+            # conversations with no agent message yet. Lets the DM panel
+            # show stable per-agent totals immediately rather than watching
+            # the count climb during hydration.
+            by_agent_name: Dict[str, int] = {}
+            try:
+                default_agent = (
+                    session.query(Agent).filter(Agent.user_id == user_id).first()
+                )
+                default_agent_name = default_agent.name if default_agent else None
+
+                conv_to_agent: Dict[str, str] = {}
+                if in_scope_ids:
+                    # Same window-style query the per-row code uses, but
+                    # bounded to the scope set.
+                    min_ts_subq = (
+                        session.query(
+                            Message.conversation_id,
+                            func.min(Message.timestamp).label("min_ts"),
+                        )
+                        .filter(
+                            Message.conversation_id.in_(in_scope_ids),
+                            Message.role != "USER",
+                            ~Message.content.like("[ACTIVITY]%"),
+                            ~Message.content.like("[SUBACTIVITY]%"),
+                        )
+                        .group_by(Message.conversation_id)
+                        .subquery()
+                    )
+                    first_agent_msgs = (
+                        session.query(Message.conversation_id, Message.role)
+                        .join(
+                            min_ts_subq,
+                            and_(
+                                Message.conversation_id
+                                == min_ts_subq.c.conversation_id,
+                                Message.timestamp == min_ts_subq.c.min_ts,
+                            ),
+                        )
+                        .filter(
+                            Message.role != "USER",
+                            ~Message.content.like("[ACTIVITY]%"),
+                            ~Message.content.like("[SUBACTIVITY]%"),
+                        )
+                        .all()
+                    )
+                    for conv_id_val, role in first_agent_msgs:
+                        cid = str(conv_id_val)
+                        if cid not in conv_to_agent and role:
+                            conv_to_agent[cid] = str(role)
+
+                for cid in in_scope_ids:
+                    name = conv_to_agent.get(cid) or default_agent_name
+                    if name:
+                        by_agent_name[name] = by_agent_name.get(name, 0) + 1
+            except Exception as exc:  # pragma: no cover - defensive
+                logging.debug(f"by_agent breakdown failed: {exc}")
+                by_agent_name = {}
+
+            return {
+                "total": int(total),
+                "pinned": int(pinned),
+                "unread": int(unread),
+                "by_agent": by_agent_name,
+            }
+        finally:
+            session.close()
+
+    def get_conversations_with_detail(
+        self,
+        limit=None,
+        offset=0,
+        cursor=None,
+    ):
         """
         OPTIMIZED: Single query to get all conversation details with notifications
         and last message timestamps in one batch instead of N+1 queries.
@@ -1199,7 +1406,22 @@ class Conversations:
                 key=lambda pair: pair[1] or pair[0].updated_at or "",
                 reverse=True,
             )
-            conversations = conversations[offset : offset + limit]
+            # Cursor-based pagination. ``cursor`` is the ISO timestamp of the
+            # last conversation the client has — we drop everything at or
+            # newer than that and return the next ``limit`` rows. Lets clients
+            # walk past offset=10500 in O(log n) instead of forcing the DB to
+            # scan/discard 10500 rows. Falls back to offset pagination when
+            # cursor is omitted, preserving backward compatibility.
+            if cursor:
+                cursor_str = str(cursor)
+                conversations = [
+                    pair
+                    for pair in conversations
+                    if str(pair[1] or pair[0].updated_at or "") < cursor_str
+                ]
+                conversations = conversations[:limit]
+            else:
+                conversations = conversations[offset : offset + limit]
 
         # Batch-fetch participant records for this user to get last_read_at
         all_conv_ids = [str(c.id) for c, _ in conversations]
@@ -1633,6 +1855,162 @@ class Conversations:
 
         session.close()
         return results
+
+    def search_conversations(
+        self,
+        query: str,
+        limit: int = 25,
+        company_id: str = None,
+    ):
+        """Sidebar-ready conversation search.
+
+        Unlike :meth:`search_messages` (which returns one row per matching
+        message and is intended for the search-results page), this returns at
+        most one entry per conversation, ranked by recency, with the fields the
+        sidebar needs to render a row directly: id, name, agent_name,
+        updated_at, snippet.
+
+        Searches across conversation name, summary, and message content.
+        """
+        session = get_session()
+        user_id = self._user_id
+        if not user_id or not query or not query.strip():
+            session.close()
+            return []
+
+        try:
+            term = f"%{query.strip()}%"
+            cap = max(1, min(int(limit or 25), 100))
+
+            participant_rows = (
+                session.query(ConversationParticipant.conversation_id)
+                .filter(
+                    ConversationParticipant.user_id == user_id,
+                    ConversationParticipant.participant_type == "user",
+                    ConversationParticipant.status == "active",
+                )
+                .all()
+            )
+            participant_conv_id_list = [str(row[0]) for row in participant_rows]
+            participant_clause = (
+                Conversation.id.in_(participant_conv_id_list)
+                if participant_conv_id_list
+                else False
+            )
+
+            scope_filter = and_(
+                or_(Conversation.user_id == user_id, participant_clause),
+                or_(
+                    Conversation.conversation_type.is_(None),
+                    Conversation.conversation_type.notin_(["group", "thread"]),
+                ),
+            )
+            if company_id:
+                scope_filter = and_(scope_filter, Conversation.company_id == company_id)
+
+            # Conversations whose name or summary directly matches.
+            meta_matches = (
+                session.query(Conversation)
+                .filter(
+                    scope_filter,
+                    or_(
+                        Conversation.name.ilike(term),
+                        Conversation.summary.ilike(term),
+                    ),
+                )
+                .order_by(Conversation.updated_at.desc())
+                .limit(cap)
+                .all()
+            )
+
+            # Conversations whose message content matches. Rank by latest matching
+            # message timestamp so the most-recently-relevant rows surface first.
+            content_subq = (
+                session.query(
+                    Message.conversation_id.label("cid"),
+                    func.max(Message.timestamp).label("ts"),
+                    func.max(Message.content).label("snippet"),
+                )
+                .filter(
+                    Message.content.ilike(term),
+                    ~Message.content.like("[ACTIVITY]%"),
+                    ~Message.content.like("[SUBACTIVITY]%"),
+                )
+                .group_by(Message.conversation_id)
+                .subquery()
+            )
+
+            content_matches = (
+                session.query(Conversation, content_subq.c.ts, content_subq.c.snippet)
+                .join(content_subq, content_subq.c.cid == Conversation.id)
+                .filter(scope_filter)
+                .order_by(content_subq.c.ts.desc())
+                .limit(cap)
+                .all()
+            )
+
+            seen = set()
+            results = []
+            _convert_time_fast = _make_time_converter(user_id)
+
+            def _snippet_for(text: str) -> str:
+                if not text:
+                    return ""
+                # Center the snippet on the first match, with up to 80 chars
+                # of context on each side.
+                lower = text.lower()
+                hit = lower.find(query.strip().lower())
+                if hit < 0:
+                    return text[:200]
+                start = max(0, hit - 80)
+                end = min(len(text), hit + 80 + len(query))
+                snippet = text[start:end]
+                if start > 0:
+                    snippet = "…" + snippet
+                if end < len(text):
+                    snippet = snippet + "…"
+                return snippet
+
+            for conv in meta_matches:
+                cid = str(conv.id)
+                if cid in seen:
+                    continue
+                seen.add(cid)
+                results.append(
+                    {
+                        "id": cid,
+                        "name": conv.name,
+                        "summary": conv.summary,
+                        "agent_name": None,
+                        "conversation_type": conv.conversation_type,
+                        "updated_at": _convert_time_fast(conv.updated_at),
+                        "snippet": (conv.summary or conv.name or "")[:200],
+                        "match_type": "metadata",
+                    }
+                )
+
+            for conv, ts, snippet_content in content_matches:
+                cid = str(conv.id)
+                if cid in seen:
+                    continue
+                seen.add(cid)
+                results.append(
+                    {
+                        "id": cid,
+                        "name": conv.name,
+                        "summary": conv.summary,
+                        "agent_name": None,
+                        "conversation_type": conv.conversation_type,
+                        "updated_at": _convert_time_fast(ts or conv.updated_at),
+                        "snippet": _snippet_for(snippet_content or ""),
+                        "match_type": "content",
+                    }
+                )
+
+            results.sort(key=lambda r: r["updated_at"] or "", reverse=True)
+            return results[:cap]
+        finally:
+            session.close()
 
     def get_conversation_changes(self, since_timestamp=None, last_known_ids=None):
         """

--- a/agixt/DB.py
+++ b/agixt/DB.py
@@ -6455,6 +6455,80 @@ def migrate_performance_indexes():
         logging.warning(f"Performance indexes migration error: {e}", exc_info=True)
 
 
+def migrate_search_indexes():
+    """Speed up conversation + message text search.
+
+    /v1/conversations/search runs ILIKE %q% across Conversation.name,
+    Conversation.summary, and Message.content. Without an index those scans
+    are O(n) and unbearable once a user has tens of thousands of messages.
+
+    On PostgreSQL we install ``pg_trgm`` and create GIN indexes that the
+    planner can use for ILIKE queries verbatim — no query rewrite needed
+    on the application side. On SQLite we fall back to LOWER()-based btree
+    indexes which are still faster than table scans for simple ILIKE.
+    Idempotent (CREATE INDEX IF NOT EXISTS / pg_trgm CREATE EXTENSION IF NOT EXISTS).
+    """
+    if engine is None:
+        return
+    try:
+        with get_db_session() as session:
+            if DATABASE_TYPE == "sqlite":
+                # SQLite doesn't have a trigram index, but a btree on LOWER()
+                # of the searchable column is still useful for prefix queries
+                # the search UI is likely to issue.
+                session.execute(
+                    text(
+                        "CREATE INDEX IF NOT EXISTS ix_conversation_name_lower "
+                        "ON conversation(LOWER(name))"
+                    )
+                )
+                session.execute(
+                    text(
+                        "CREATE INDEX IF NOT EXISTS ix_conversation_summary_lower "
+                        "ON conversation(LOWER(summary))"
+                    )
+                )
+                # Message.content is too long for a useful btree on LOWER()
+                # in SQLite — leave the LIKE scan unindexed there. Most users
+                # run Postgres in production and get the trigram benefit.
+            else:
+                # PostgreSQL: enable pg_trgm and add GIN indexes that match
+                # ILIKE queries verbatim.
+                try:
+                    session.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+                except Exception as exc:
+                    # Some Postgres deployments don't allow CREATE EXTENSION
+                    # from the application role. Log and skip — queries still
+                    # work via sequential scan, just slower.
+                    logging.info(
+                        f"pg_trgm extension unavailable, search will use seq scan: {exc}"
+                    )
+                    return
+
+                session.execute(
+                    text(
+                        "CREATE INDEX IF NOT EXISTS ix_conversation_name_trgm "
+                        "ON conversation USING gin (name gin_trgm_ops)"
+                    )
+                )
+                session.execute(
+                    text(
+                        "CREATE INDEX IF NOT EXISTS ix_conversation_summary_trgm "
+                        "ON conversation USING gin (summary gin_trgm_ops)"
+                    )
+                )
+                session.execute(
+                    text(
+                        "CREATE INDEX IF NOT EXISTS ix_message_content_trgm "
+                        "ON message USING gin (content gin_trgm_ops)"
+                    )
+                )
+            session.commit()
+            logging.info("Search indexes migration complete")
+    except Exception as e:
+        logging.warning(f"Search indexes migration error: {e}", exc_info=True)
+
+
 def migrate_extract_data_urls_from_messages():
     """
     One-time migration to extract inline base64 data URLs from existing messages
@@ -8459,6 +8533,19 @@ def check_schema_migrations_needed():
                         return True
                 except Exception:
                     return True
+
+                # Sentinel for the search-index migration. If absent, run.
+                try:
+                    result = session.execute(
+                        text(
+                            "SELECT 1 FROM sqlite_master "
+                            "WHERE type='index' AND name='ix_conversation_name_lower'"
+                        )
+                    )
+                    if not result.fetchone():
+                        return True
+                except Exception:
+                    return True
             else:
                 # PostgreSQL - check for latest migration indicators
                 result = session.execute(
@@ -8491,6 +8578,24 @@ def check_schema_migrations_needed():
                         SELECT 1 FROM information_schema.columns
                         WHERE table_name = 'UserCompany'
                         AND column_name = 'sort_order'
+                        """
+                    )
+                )
+                if not result.fetchone():
+                    return True
+
+                # Sentinel for the search-index migration. The trigram GIN
+                # index won't exist until the new migration runs; if absent,
+                # force a migration pass. Quietly tolerate environments where
+                # pg_trgm isn't installable — the migration logs and skips
+                # in that case, so subsequent boots will re-check until the
+                # extension lands or another migration adds a different
+                # sentinel.
+                result = session.execute(
+                    text(
+                        """
+                        SELECT 1 FROM pg_indexes
+                        WHERE indexname = 'ix_conversation_name_trgm'
                         """
                     )
                 )
@@ -8540,6 +8645,7 @@ def run_all_schema_migrations():
 
     # Phase 3: Performance indexes
     migrate_performance_indexes()
+    migrate_search_indexes()
 
     # Phase 4: One-time data cleanup migrations
     migrate_cleanup_duplicate_wallet_settings()

--- a/agixt/MagicalAuth.py
+++ b/agixt/MagicalAuth.py
@@ -7720,6 +7720,13 @@ class MagicalAuth:
                                     last_name=user.last_name,
                                     role=display_role,
                                     role_id=display_role_id,
+                                    avatar_url=getattr(user, "avatar_url", None),
+                                    last_seen=(
+                                        user.last_seen.isoformat()
+                                        if getattr(user, "last_seen", None)
+                                        else None
+                                    ),
+                                    status_text=getattr(user, "status_text", None),
                                 )
 
                     company_data = {

--- a/agixt/Models.py
+++ b/agixt/Models.py
@@ -14,6 +14,10 @@ class UserResponse(BaseModel):
     role: str
     role_id: int
     avatar_url: Optional[str] = None
+    # Presence fields used by sidebar/DM avatars. Optional so callers that only
+    # populate the basics keep working unchanged.
+    last_seen: Optional[str] = None
+    status_text: Optional[str] = None
 
 
 class CompanyResponse(BaseModel):
@@ -797,6 +801,19 @@ class ConversationListResponse(BaseModel):
 
 class ConversationDetailResponse(BaseModel):
     conversations: Dict[str, Dict[str, Any]]
+    # Aggregate counts across the user's full conversation list (not just the
+    # paginated page). Lets the UI show stable totals immediately. Optional so
+    # ?include_counts=false (or older clients) keep a minimal response shape.
+    total: Optional[int] = None
+    pinned_count: Optional[int] = None
+    unread_count: Optional[int] = None
+    # Per-agent conversation counts keyed by agent name. Lets the DM panel
+    # show stable "X conversations" labels under each agent immediately
+    # rather than watching the count climb during client-side hydration.
+    by_agent: Optional[Dict[str, int]] = None
+    # Cursor pagination — pass back as ?cursor= for the next page. Null when
+    # this is the last page.
+    next_cursor: Optional[str] = None
 
 
 class ConversationHistoryResponse(BaseModel):
@@ -804,6 +821,9 @@ class ConversationHistoryResponse(BaseModel):
     total: Optional[int] = None
     page: Optional[int] = None
     limit: Optional[int] = None
+    # Echo back the format the server returned. "flat" (default) preserves the
+    # legacy shape; "tree" nests activities under their owning agent response.
+    format: Optional[str] = None
 
 
 class NewConversationHistoryResponse(BaseModel):

--- a/agixt/ResponseCache.py
+++ b/agixt/ResponseCache.py
@@ -111,29 +111,37 @@ class ResponseCacheManager:
         "/v1/scopes": 600,  # Scopes list - 10 minutes (rarely changes, system-level)
         "/v1/roles": 300,  # Custom roles - 5 minutes
         "/v1/user/scopes": 60,  # User's effective scopes - 1 minute (per-user, changes with role changes)
+        # Chat-shell warmup endpoint. Composes user + companies + recent
+        # conversations + counts + active + billing into one response. The
+        # underlying components are individually cacheable up to 30-300s,
+        # but during the typical /user → /chat redirect the same payload
+        # gets requested twice within 50ms — caching for 15s collapses the
+        # second hit to ~0ms. Mutation invalidation rules below ensure
+        # creates/edits flush this cache so stale counts don't appear.
+        "/v1/me/bootstrap": 15,
     }
 
     # Invalidation rules: when a mutation happens on path pattern, invalidate these cache patterns
     INVALIDATION_RULES = {
         # Agent mutations invalidate agent-related caches
-        "POST:/v1/agent": ["agent", "company"],
-        "PUT:/v1/agent": ["agent"],
-        "DELETE:/v1/agent": ["agent", "company"],
-        "PUT:/v1/agent/*/settings": ["agent"],
-        "PUT:/v1/agent/*/commands": ["agent"],
+        "POST:/v1/agent": ["agent", "company", "me/bootstrap"],
+        "PUT:/v1/agent": ["agent", "me/bootstrap"],
+        "DELETE:/v1/agent": ["agent", "company", "me/bootstrap"],
+        "PUT:/v1/agent/*/settings": ["agent", "me/bootstrap"],
+        "PUT:/v1/agent/*/commands": ["agent", "me/bootstrap"],
         "PATCH:/v1/agent/*/command": ["agent", "extension"],  # Single command toggle
         "PATCH:/v1/agent/*/extension/commands": [
             "agent",
             "extension",
         ],  # Bulk command toggle
         # Conversation mutations
-        "POST:/v1/conversation": ["conversation"],
-        "PUT:/v1/conversation": ["conversation"],
-        "PATCH:/v1/conversation": ["conversation"],
-        "DELETE:/v1/conversation": ["conversation"],
+        "POST:/v1/conversation": ["conversation", "me/bootstrap"],
+        "PUT:/v1/conversation": ["conversation", "me/bootstrap"],
+        "PATCH:/v1/conversation": ["conversation", "me/bootstrap"],
+        "DELETE:/v1/conversation": ["conversation", "me/bootstrap"],
         # Company mutations
-        "POST:/v1/company": ["company"],
-        "PUT:/v1/company": ["company"],
+        "POST:/v1/company": ["company", "me/bootstrap"],
+        "PUT:/v1/company": ["company", "me/bootstrap"],
         "PATCH:/v1/companies/*/command": [
             "agent",
             "extension",
@@ -200,6 +208,7 @@ class ResponseCacheManager:
         "/v1/scopes",  # All system scopes - internal, rarely changes
         "/v1/roles",  # Custom roles list - internal AGiXT data
         "/v1/user/scopes",  # User's effective scopes - per-user permissions
+        "/v1/me/bootstrap",  # Chat-shell warmup composite (15s TTL)
     }
 
     def __init__(self):

--- a/agixt/WorkerRegistry.py
+++ b/agixt/WorkerRegistry.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import time
-from typing import Dict, Set, Optional
+from typing import Callable, Dict, List, Set, Optional
 from datetime import datetime
 import threading
 
@@ -23,6 +23,32 @@ class WorkerRegistry:
         )  # conversation_id -> task
         self._stopped_conversations: Set[str] = set()  # explicitly stopped by user
         self._lock = threading.Lock()
+        # Listeners notified whenever a conversation transitions between
+        # working and idle. Each listener receives ``(event, info_dict)`` where
+        # ``event`` is "started" or "ended". Used by the WebSocket layer to
+        # push live state changes to the frontend so it can stop polling
+        # /v1/conversations/active every 15 seconds.
+        self._state_listeners: List[Callable[[str, Dict], None]] = []
+
+    def add_state_listener(self, listener: Callable[[str, Dict], None]) -> None:
+        """Register a listener for working/idle transitions.
+
+        The listener runs synchronously inside the registry's lock-free path
+        (after the lock is released) so it MUST not raise. It SHOULD schedule
+        any async work via ``asyncio.create_task`` and return immediately.
+        """
+        with self._lock:
+            self._state_listeners.append(listener)
+
+    def _emit_state(self, event: str, info: Dict) -> None:
+        # Snapshot listeners outside any held lock to keep callbacks decoupled
+        # from registry internals.
+        listeners = list(self._state_listeners)
+        for listener in listeners:
+            try:
+                listener(event, info)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning(f"WorkerRegistry state listener failed: {exc}")
 
     def register_conversation(
         self,
@@ -56,7 +82,18 @@ class WorkerRegistry:
             if task:
                 self._conversation_tasks[conversation_id] = task
 
-            return conversation_id
+        # Emit AFTER releasing the lock so listener callbacks can do whatever
+        # they need (including reading registry state) without deadlocking.
+        self._emit_state(
+            "started",
+            {
+                "conversation_id": conversation_id,
+                "user_id": user_id,
+                "agent_name": agent_name,
+                "started_at": worker_info["started_at"].isoformat(),
+            },
+        )
+        return conversation_id
 
     def unregister_conversation(self, conversation_id: str) -> bool:
         """
@@ -68,9 +105,16 @@ class WorkerRegistry:
         Returns:
             bool: True if conversation was found and removed
         """
+        info_snapshot: Optional[Dict] = None
         with self._lock:
             removed = False
             if conversation_id in self._active_conversations:
+                info_snapshot = self._active_conversations[conversation_id].copy()
+                # Drop the unserializable task before notifying listeners.
+                info_snapshot.pop("task", None)
+                started_at = info_snapshot.get("started_at")
+                if isinstance(started_at, datetime):
+                    info_snapshot["started_at"] = started_at.isoformat()
                 del self._active_conversations[conversation_id]
                 removed = True
 
@@ -79,7 +123,9 @@ class WorkerRegistry:
 
             self._stopped_conversations.discard(conversation_id)
 
-            return removed
+        if removed and info_snapshot is not None:
+            self._emit_state("ended", info_snapshot)
+        return removed
 
     def is_stopped(self, conversation_id: str) -> bool:
         """Check if a conversation was explicitly stopped by the user."""

--- a/agixt/app.py
+++ b/agixt/app.py
@@ -35,6 +35,7 @@ from endpoints.Roles import app as roles_endpoints
 from endpoints.ServerConfig import app as server_config_endpoints
 from endpoints.ApiKey import app as apikey_endpoints
 from endpoints.Voice import app as voice_endpoints
+from endpoints.Bootstrap import app as bootstrap_endpoints
 from Globals import getenv
 from contextlib import asynccontextmanager
 from Workspaces import WorkspaceManager
@@ -300,6 +301,7 @@ app.include_router(roles_endpoints)
 app.include_router(server_config_endpoints)
 app.include_router(apikey_endpoints)
 app.include_router(voice_endpoints)
+app.include_router(bootstrap_endpoints)
 
 # Bot webhook routers (for inbound email/SMS processing)
 try:

--- a/agixt/endpoints/Bootstrap.py
+++ b/agixt/endpoints/Bootstrap.py
@@ -1,0 +1,194 @@
+"""Single-shot warmup endpoint for the chat shell.
+
+The web client otherwise opens 6–8 parallel SWR requests on every cold mount of
+``/chat`` (user, companies, agent, scopes, billing, conversations, active
+conversations, presence). Each adds a TLS round trip; on slow connections or
+on `/user → /chat` redirects with no warm cache the perceived hang is mostly
+this fan-out. Composing the same payload server-side cuts that to one request.
+
+The shape is intentionally a superset of the individual endpoints so the
+client can seed each SWR cache key once at app shell mount and individual
+hooks become no-ops on first render. Existing endpoints stay live and
+unchanged — this is purely additive.
+"""
+
+import asyncio
+import logging
+import time
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+
+from ApiClient import verify_api_key
+from Conversations import Conversations
+from MagicalAuth import MagicalAuth
+from WorkerRegistry import worker_registry
+
+app = APIRouter()
+
+
+@app.get(
+    "/v1/me/bootstrap",
+    summary="Single-shot chat shell warmup",
+    description=(
+        "Returns user identity + companies + agents + scopes + recent "
+        "conversations + counts + active conversations + billing flag in one "
+        "call. Replaces the 6–8 parallel SWR requests the chat page fires on "
+        "cold mount. Safe to call repeatedly — composes existing read-only "
+        "endpoints with no side effects."
+    ),
+    tags=["Bootstrap"],
+    dependencies=[Depends(verify_api_key)],
+)
+async def me_bootstrap(
+    user=Depends(verify_api_key),
+    authorization: str = Header(None),
+    recent_limit: int = 50,
+):
+    if recent_limit <= 0:
+        recent_limit = 50
+    if recent_limit > 200:
+        recent_limit = 200
+
+    auth = MagicalAuth(token=authorization)
+
+    payload: Dict[str, Any] = {}
+    section_timings: Dict[str, float] = {}
+
+    def _slim_companies(companies):
+        """Strip the heaviest fields (per-agent commands, base64 icon_url)
+        from the bundle. Cuts the chat-shell payload roughly in half on
+        accounts with multiple companies × agents — chat doesn't need
+        commands until the user actually opens an agent picker, and the
+        full /v1/user fetch that the client SWR fires a moment later
+        carries everything for consumers that do."""
+        slim_list = []
+        for c in companies or []:
+            if not isinstance(c, dict):
+                slim_list.append(c)
+                continue
+            slim = {k: v for k, v in c.items() if k != "icon_url"}
+            agents = slim.get("agents")
+            if isinstance(agents, list):
+                slim["agents"] = [
+                    (
+                        {ak: av for ak, av in a.items() if ak != "commands"}
+                        if isinstance(a, dict)
+                        else a
+                    )
+                    for a in agents
+                ]
+            slim_list.append(slim)
+        return slim_list
+
+    def _load_user_bundle():
+        t0 = time.perf_counter()
+        bundle = auth.get_user_data_optimized()
+        section_timings["user_bundle"] = (time.perf_counter() - t0) * 1000
+        return bundle
+
+    def _load_conversations():
+        t0 = time.perf_counter()
+        c = Conversations(user=user)
+        convs = c.get_conversations_with_detail(limit=recent_limit, offset=0) or {}
+        section_timings["recent_conversations"] = (time.perf_counter() - t0) * 1000
+        return convs
+
+    def _load_counts():
+        t0 = time.perf_counter()
+        c = Conversations(user=user)
+        counts = c.get_conversation_counts()
+        section_timings["counts"] = (time.perf_counter() - t0) * 1000
+        return counts
+
+    def _load_active():
+        t0 = time.perf_counter()
+        active = worker_registry.get_user_conversations(user_id=auth.user_id) or {}
+        for _, info in active.items():
+            info.pop("task", None)
+        section_timings["active"] = (time.perf_counter() - t0) * 1000
+        return active
+
+    def _load_billing():
+        t0 = time.perf_counter()
+        try:
+            from ExtensionsHub import ExtensionsHub
+            from Globals import getenv
+
+            if getenv("BILLING_PAUSED", "false").lower() == "true":
+                section_timings["billing"] = (time.perf_counter() - t0) * 1000
+                return False
+            hub = ExtensionsHub()
+            try:
+                cfg = hub.get_pricing_config()
+            except Exception:
+                cfg = hub.get_default_pricing_config()
+            value = bool(
+                cfg.get("billing_enabled", True) if isinstance(cfg, dict) else True
+            )
+            section_timings["billing"] = (time.perf_counter() - t0) * 1000
+            return value
+        except Exception:
+            section_timings["billing"] = (time.perf_counter() - t0) * 1000
+            return None
+
+    # All five sections are independent — they each open their own DB session
+    # internally — so we can run them in parallel via threadpool. On the
+    # 11k-conversation account this reduces total latency from
+    # max(t_user, t_conv, t_counts, ...) summed sequentially to the slowest
+    # branch alone (typically the conversations fetch).
+    overall_t0 = time.perf_counter()
+    try:
+        (
+            user_bundle,
+            recent_conversations,
+            counts,
+            active,
+            billing_enabled,
+        ) = await asyncio.gather(
+            asyncio.to_thread(_load_user_bundle),
+            asyncio.to_thread(_load_conversations),
+            asyncio.to_thread(_load_counts),
+            asyncio.to_thread(_load_active),
+            asyncio.to_thread(_load_billing),
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logging.error(f"bootstrap: parallel load failed: {exc}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to assemble bootstrap.")
+    section_timings["total_parallel"] = (time.perf_counter() - overall_t0) * 1000
+
+    user_record = user_bundle["user"]
+    preferences = user_bundle.get("preferences", {})
+    payload["user"] = {
+        "id": auth.user_id,
+        "email": user_record.email,
+        "first_name": user_record.first_name,
+        "last_name": user_record.last_name,
+        "username": getattr(user_record, "username", None),
+        "avatar_url": getattr(user_record, "avatar_url", None),
+        "last_seen": (
+            user_record.last_seen.isoformat()
+            if getattr(user_record, "last_seen", None)
+            else None
+        ),
+        "status_text": getattr(user_record, "status_text", None),
+        "tos_accepted_at": (
+            user_record.tos_accepted_at.isoformat()
+            if user_record.tos_accepted_at
+            else None
+        ),
+        **preferences,
+    }
+    payload["companies"] = _slim_companies(user_bundle.get("companies", []))
+    payload["recent_conversations"] = recent_conversations
+    payload["conversations_total"] = (counts or {}).get("total", 0)
+    payload["conversations_pinned_count"] = (counts or {}).get("pinned", 0)
+    payload["conversations_unread_count"] = (counts or {}).get("unread", 0)
+    payload["conversations_by_agent"] = (counts or {}).get("by_agent", {})
+    payload["active_conversations"] = active
+    payload["billing_enabled"] = billing_enabled
+
+    logging.info(f"bootstrap timings (ms): {section_timings}")
+    return payload

--- a/agixt/endpoints/Conversation.py
+++ b/agixt/endpoints/Conversation.py
@@ -12,7 +12,7 @@ from fastapi import (
 from fastapi.responses import StreamingResponse, JSONResponse, Response
 import hashlib
 from pydantic import BaseModel
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from ApiClient import verify_api_key, get_api_client, Agent
 from Conversations import (
     Conversations,
@@ -774,6 +774,8 @@ async def get_conversations(
     user=Depends(verify_api_key),
     limit: int = None,
     offset: int = 0,
+    cursor: Optional[str] = None,
+    include_counts: bool = True,
     if_none_match: str = Header(None, alias="If-None-Match"),
 ):
     c = Conversations(user=user)
@@ -784,17 +786,51 @@ async def get_conversations(
     MAX_CONVERSATIONS = 500
     if limit is None or limit <= 0 or limit > MAX_CONVERSATIONS:
         limit = MAX_CONVERSATIONS
-    # Pass limit/offset to the core method so expensive batch queries
+    # Pass limit/offset/cursor to the core method so expensive batch queries
     # (unread counts, DM names, agent roles) are only computed for the
     # paginated subset instead of all conversations.
-    conversations = c.get_conversations_with_detail(limit=limit, offset=offset)
+    conversations = c.get_conversations_with_detail(
+        limit=limit, offset=offset, cursor=cursor
+    )
     if not conversations:
         conversations = {}
+
+    # Cheap aggregate counts so frontends can show stable "X conversations"
+    # labels immediately, without waiting for full client-side hydration.
+    # Defaults to on; an explicit ?include_counts=false skips the extra
+    # COUNT() queries (a few ms) for callers that don't need them.
+    payload = {"conversations": conversations}
+    if include_counts:
+        try:
+            counts = c.get_conversation_counts()
+        except (
+            Exception
+        ) as exc:  # pragma: no cover - defensive: never break list response on count failure
+            logging.warning(f"get_conversation_counts failed, omitting counts: {exc}")
+            counts = None
+        if counts is not None:
+            payload["total"] = counts.get("total", 0)
+            payload["pinned_count"] = counts.get("pinned", 0)
+            payload["unread_count"] = counts.get("unread", 0)
+            payload["by_agent"] = counts.get("by_agent", {})
+    # Cursor for the next page: the updated_at of the last row returned.
+    # Clients pass this back as ?cursor=… to skip O(offset) row discards on
+    # the database side. Null when this page is the last page.
+    if (
+        conversations
+        and isinstance(conversations, dict)
+        and len(conversations) >= limit
+    ):
+        last_entry = next(reversed(conversations.values()))
+        payload["next_cursor"] = last_entry.get("updated_at")
+    else:
+        payload["next_cursor"] = None
+
     # Conversations contain datetime values that JSONResponse can't serialize
     # directly; use jsonable_encoder to normalize before hashing/sending.
     from fastapi.encoders import jsonable_encoder
 
-    encoded = jsonable_encoder({"conversations": conversations})
+    encoded = jsonable_encoder(payload)
 
     # ETag based on response content. Lets the SSR layout fetch return 304
     # Not Modified on warm navigation, avoiding the 100-400ms recompute of
@@ -841,10 +877,111 @@ async def search_messages(
 
 
 @app.get(
+    "/v1/conversations/search",
+    summary="Search Conversations (sidebar-ready)",
+    description=(
+        "Search across conversation name, summary, and recent message content "
+        "and return at most one entry per conversation with the fields the "
+        "sidebar/DM panel needs to render a row directly. Use this for "
+        "type-to-search UX in accounts with many conversations; the POST "
+        "variant is still available for full message-level search."
+    ),
+    tags=["Conversation"],
+    dependencies=[Depends(verify_api_key)],
+)
+async def search_conversations(
+    q: str,
+    limit: int = 25,
+    company_id: Optional[str] = None,
+    user=Depends(verify_api_key),
+):
+    c = Conversations(user=user)
+    results = c.search_conversations(query=q, limit=limit, company_id=company_id)
+    return {"results": results}
+
+
+def _group_activities_into_tree(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Nest [ACTIVITY] (and their [SUBACTIVITY] children) under the following
+    non-activity message in the same conversation.
+
+    Long-horizon agent runs emit hundreds of activity rows interleaved with the
+    user message and the final agent response. The flat shape forces clients
+    to walk the whole list every render to re-pair activities with their owner.
+    The tree shape collapses those 500+ rows into a single "response with
+    activities" entry on the wire — same payload, dramatically smaller React
+    tree, and the client's grouping pass becomes the identity function.
+
+    Activities at the tail of a conversation (no following response yet,
+    e.g. agent is still working) are returned as a synthetic group with
+    ``response = None`` so the UI can render them under "in progress".
+    """
+    grouped: List[Dict[str, Any]] = []
+    pending: List[Dict[str, Any]] = []
+    sub_buffer: List[Dict[str, Any]] = []
+
+    def flush_subs_to(activity: Dict[str, Any]) -> None:
+        if sub_buffer:
+            activity.setdefault("subactivities", []).extend(sub_buffer)
+            sub_buffer.clear()
+
+    for msg in messages:
+        content = str(msg.get("message") or "")
+        if content.startswith("[SUBACTIVITY]"):
+            sub_buffer.append(msg)
+            continue
+        if content.startswith("[ACTIVITY]"):
+            # Hand any subactivities accumulated since the last activity to the
+            # previous activity (they belong to it, not the next one).
+            if pending:
+                flush_subs_to(pending[-1])
+            else:
+                # Subactivities before any activity: leave them at the top of
+                # the next activity once one shows up. Drop on the floor if
+                # none follows (shouldn't happen in practice).
+                sub_buffer.clear()
+            pending.append({**msg, "subactivities": []})
+            continue
+        # Non-activity message — close out the running activity group.
+        if pending:
+            flush_subs_to(pending[-1])
+        grouped.append(
+            {
+                **msg,
+                "activities": pending,
+            }
+        )
+        pending = []
+        sub_buffer.clear()
+
+    # Trailing activities with no closing response: emit a synthetic group so
+    # the frontend can render them under "still working". response_id is None
+    # so callers can distinguish from completed groups.
+    if pending:
+        flush_subs_to(pending[-1])
+        grouped.append(
+            {
+                "id": None,
+                "role": pending[0].get("role"),
+                "message": "",
+                "timestamp": pending[0].get("timestamp"),
+                "activities": pending,
+                "is_pending": True,
+            }
+        )
+
+    return grouped
+
+
+@app.get(
     "/v1/conversation/{conversation_id}",
     response_model=ConversationHistoryResponse,
     summary="Get Conversation History by ID",
-    description="Retrieves the complete history of a specific conversation using its ID.",
+    description=(
+        "Retrieves the complete history of a specific conversation using its ID. "
+        "Pass ?format=tree to receive activities nested under their owning "
+        "agent response (recommended for long-horizon tasks; cuts the top-level "
+        "message array from 500+ to a handful)."
+    ),
     tags=["Conversation"],
     dependencies=[Depends(verify_api_key)],
 )
@@ -854,6 +991,7 @@ async def get_conversation_history(
     authorization: str = Header(None),
     limit: int = 100,
     page: int = 1,
+    format: str = "flat",
 ):
     auth = MagicalAuth(token=authorization)
     if conversation_id == "-":
@@ -879,11 +1017,14 @@ async def get_conversation_history(
     resp_limit = conversation_history.get("limit")
     if "interactions" in conversation_history:
         conversation_history = conversation_history["interactions"]
+    if format == "tree":
+        conversation_history = _group_activities_into_tree(conversation_history)
     return {
         "conversation_history": conversation_history,
         "total": total,
         "page": resp_page,
         "limit": resp_limit,
+        "format": format,
     }
 
 
@@ -3190,6 +3331,98 @@ async def notify_user_conversation_renamed(
             },
         },
     )
+
+
+async def notify_user_agent_working(
+    user_id: str,
+    conversation_id: str,
+    event: str,
+    agent_name: Optional[str] = None,
+    started_at: Optional[str] = None,
+):
+    """Push a working/idle transition for a conversation.
+
+    Replaces the frontend's 15s ``/v1/conversations/active`` polling: the
+    web client subscribes to the existing user-notification WebSocket and
+    pivots its ``isAgentWorking`` state on these events instead.
+    """
+    await user_notification_manager.broadcast_to_user(
+        user_id,
+        {
+            "type": (
+                "agent_working_started" if event == "started" else "agent_working_ended"
+            ),
+            "data": {
+                "conversation_id": conversation_id,
+                "agent_name": agent_name,
+                "started_at": started_at,
+                "timestamp": datetime.now().isoformat(),
+            },
+        },
+    )
+
+
+def _on_worker_state_change(event: str, info: Dict[str, Any]) -> None:
+    """Bridge: WorkerRegistry sync callback → async user-notification broadcast.
+
+    The registry callback runs in whatever thread/coroutine context triggered
+    the registration. Schedule the async broadcast on the FastAPI main loop so
+    it lands on the user's WebSocket without blocking the registration call.
+    """
+    user_id = info.get("user_id")
+    conversation_id = info.get("conversation_id")
+    if not user_id or not conversation_id:
+        return
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            asyncio.create_task(
+                notify_user_agent_working(
+                    user_id=str(user_id),
+                    conversation_id=str(conversation_id),
+                    event=event,
+                    agent_name=info.get("agent_name"),
+                    started_at=info.get("started_at"),
+                )
+            )
+        else:
+            asyncio.run_coroutine_threadsafe(
+                notify_user_agent_working(
+                    user_id=str(user_id),
+                    conversation_id=str(conversation_id),
+                    event=event,
+                    agent_name=info.get("agent_name"),
+                    started_at=info.get("started_at"),
+                ),
+                loop,
+            )
+    except RuntimeError:
+        # No event loop in this thread (e.g. registration from a worker
+        # thread). Fall back to publishing through the same Redis channel
+        # the user_notification_manager already uses for cross-worker fanout.
+        try:
+            user_notification_manager._publish_to_redis(
+                str(user_id),
+                {
+                    "type": (
+                        "agent_working_started"
+                        if event == "started"
+                        else "agent_working_ended"
+                    ),
+                    "data": {
+                        "conversation_id": str(conversation_id),
+                        "agent_name": info.get("agent_name"),
+                        "started_at": info.get("started_at"),
+                        "timestamp": datetime.now().isoformat(),
+                    },
+                },
+            )
+        except Exception as exc:
+            logging.debug(f"agent_working broadcast fallback failed: {exc}")
+
+
+# Wire WorkerRegistry → user_notification_manager exactly once at import.
+worker_registry.add_state_listener(_on_worker_state_change)
 
 
 async def notify_user_message_added(


### PR DESCRIPTION
## Summary

- Adds `/v1/me/bootstrap` as a single-shot chat shell warmup endpoint for user, company, conversation, active-conversation, and billing state.
- Adds a Redis-backed response cache middleware with local-memory fallback, mutation invalidation, and cache stats/clear endpoints.
- Adds active conversation tracking through `WorkerRegistry` for faster active-state updates.
- Adds conversation count/cursor metadata and search indexes for conversation/message search performance.

## Validation

- Passed: `/home/josh/repos/xtsys/.venv/bin/python -m py_compile` on all changed AGiXT Python files.

## Review Notes Before Merge

- Draft because review found issues that deserve follow-up before treating this as merge-ready.
- `ResponseCacheMiddleware` caches GET paths by broad prefix. `/v1/conversation` includes streaming workspace downloads such as `/v1/conversation/{conversation_id}/workspace/download`, so the middleware can consume the stream into memory and return a buffered non-streaming response.
- Cache identity uses `md5(token)` rather than the real user id. That avoids JWT decode cost, but token refreshes and multiple sessions get separate cache namespaces, so mutations from one token can leave another active token's cached data stale.
- PostgreSQL search-index migration uses `ix_conversation_name_trgm` as the readiness sentinel. If the app role cannot create `pg_trgm`, the migration logs and skips, but startup can continue to detect the missing sentinel on later boots.
