### PR TITLE
Add MiniMax provider extension

### DIFF
--- a/agixt/extensions/minimax.py
+++ b/agixt/extensions/minimax.py
@@ -26,6 +26,7 @@ API_URIS = {
     "global_en_anthropic": "https://api.minimax.io/anthropic",
     "cn_zh_anthropic": "https://api.minimaxi.com/anthropic",
 }
+ANTHROPIC_API_VERSION = "2023-06-01"
 MODEL_CONTEXT_WINDOWS = {
     "MiniMax-M3": 1_000_000,
     "MiniMax-M2.7": 204_800,
@@ -331,11 +332,20 @@ class minimax(Extensions):
             payload["max_tokens"] = self.MAX_OUTPUT_TOKENS
             payload["stop_sequences"] = ["</execute>"]
             api_url = f"{self.API_URI}/v1/messages"
+            headers = {
+                "x-api-key": self.MINIMAX_API_KEY,
+                "anthropic-version": ANTHROPIC_API_VERSION,
+                "Content-Type": "application/json",
+            }
         else:
             payload["max_completion_tokens"] = self.MAX_OUTPUT_TOKENS
             payload["n"] = 1
             payload["stop"] = ["</execute>"]
             api_url = f"{self.API_URI}/chat/completions"
+            headers = {
+                "Authorization": f"Bearer {self.MINIMAX_API_KEY}",
+                "Content-Type": "application/json",
+            }
         if self.AI_MODEL == "MiniMax-M3":
             if self.THINKING:
                 payload["thinking"] = {"type": self.THINKING}
@@ -344,10 +354,7 @@ class minimax(Extensions):
         try:
             response = requests.post(
                 api_url,
-                headers={
-                    "Authorization": f"Bearer {self.MINIMAX_API_KEY}",
-                    "Content-Type": "application/json",
-                },
+                headers=headers,
                 json=payload,
                 stream=stream,
                 timeout=300,

--- a/agixt/extensions/minimax.py
+++ b/agixt/extensions/minimax.py
@@ -1,0 +1,302 @@
+"""
+MiniMax AI provider extension for AGiXT.
+
+This extension uses the MiniMax chat completions API for text, image, and video
+inference. Set MINIMAX_API_URI to global_en, cn_zh, or a custom compatible base
+URL. API keys are available from https://platform.minimax.io/ and
+https://platform.minimaxi.com/.
+"""
+
+import base64
+import json
+import logging
+import time
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import requests
+
+from Extensions import Extensions
+from Globals import getenv
+
+API_URIS = {
+    "global_en": "https://api.minimax.io/v1",
+    "cn_zh": "https://api.minimaxi.com/v1",
+}
+MODEL_CONTEXT_WINDOWS = {
+    "MiniMax-M3": 1_000_000,
+    "MiniMax-M2.7": 204_800,
+}
+MODEL_TOP_P_DEFAULTS = {
+    "MiniMax-M3": 0.95,
+    "MiniMax-M2.7": 0.9,
+}
+MEDIA_TYPES = {
+    ".jpg": ("image_url", "image/jpeg"),
+    ".jpeg": ("image_url", "image/jpeg"),
+    ".png": ("image_url", "image/png"),
+    ".gif": ("image_url", "image/gif"),
+    ".webp": ("image_url", "image/webp"),
+    ".mp4": ("video_url", "video/mp4"),
+    ".avi": ("video_url", "video/x-msvideo"),
+    ".mov": ("video_url", "video/quicktime"),
+    ".mkv": ("video_url", "video/x-matroska"),
+}
+
+
+class StreamChunk:
+    """Provide the streaming interface expected by AGiXT."""
+
+    def __init__(self, data: dict):
+        self._data = data
+        self.choices = [StreamChoice(choice) for choice in data.get("choices", [])]
+
+
+class StreamChoice:
+    """Wrap one streamed response choice."""
+
+    def __init__(self, choice_data: dict):
+        self.delta = StreamDelta(choice_data.get("delta", {}))
+        self.finish_reason = choice_data.get("finish_reason")
+
+
+class StreamDelta:
+    """Expose streamed text and reasoning fields."""
+
+    def __init__(self, delta_data: dict):
+        self.content = delta_data.get("content")
+        self.reasoning_content = delta_data.get("reasoning_content")
+        self.reasoning_details = delta_data.get("reasoning_details")
+        self.role = delta_data.get("role")
+
+
+def parse_sse_stream(response):
+    """Parse a server-sent event response into AGiXT stream chunks."""
+    for line in response.iter_lines():
+        if not line:
+            continue
+        line_text = line.decode("utf-8") if isinstance(line, bytes) else line
+        if not line_text.startswith("data:"):
+            continue
+        data_text = line_text[5:].lstrip()
+        if data_text == "[DONE]":
+            break
+        try:
+            yield StreamChunk(json.loads(data_text))
+        except json.JSONDecodeError:
+            continue
+
+
+def _media_type(media: str):
+    if media.startswith("data:image/"):
+        return "image_url", None
+    if media.startswith("data:video/") or media.startswith("mm_file://"):
+        return "video_url", None
+
+    path = urlsplit(media).path if media.startswith(("http://", "https://")) else media
+    media_type = MEDIA_TYPES.get(Path(path).suffix.lower())
+    if media_type:
+        return media_type
+    if media.startswith(("http://", "https://")):
+        return "image_url", None
+    raise ValueError(f"Unsupported MiniMax media type: {media}")
+
+
+def _media_content_part(media: str):
+    content_type, mime_type = _media_type(media)
+    if media.startswith(("http://", "https://", "data:", "mm_file://")):
+        media_url = media
+    else:
+        with open(media, "rb") as media_file:
+            encoded_media = base64.b64encode(media_file.read()).decode("utf-8")
+        media_url = f"data:{mime_type};base64,{encoded_media}"
+    return {"type": content_type, content_type: {"url": media_url}}
+
+
+class minimax(Extensions):
+    """MiniMax provider for language and multimodal inference."""
+
+    CATEGORY = "AI Provider"
+    friendly_name = "MiniMax"
+    SERVICES = ["llm", "vision"]
+
+    def __init__(
+        self,
+        MINIMAX_API_KEY: str = "",
+        MINIMAX_MODEL: str = "MiniMax-M3",
+        MINIMAX_API_URI: str = API_URIS["global_en"],
+        MINIMAX_MAX_TOKENS: int = 0,
+        MINIMAX_MAX_OUTPUT_TOKENS: int = 4096,
+        MINIMAX_TEMPERATURE: float = 1.0,
+        MINIMAX_TOP_P: float = None,
+        MINIMAX_THINKING: str = "adaptive",
+        MINIMAX_SERVICE_TIER: str = "standard",
+        MINIMAX_WAIT_BETWEEN_REQUESTS: int = 0,
+        MINIMAX_WAIT_AFTER_FAILURE: int = 3,
+        **kwargs,
+    ):
+        if not MINIMAX_API_KEY:
+            MINIMAX_API_KEY = getenv("MINIMAX_API_KEY", "")
+        if not MINIMAX_MODEL or MINIMAX_MODEL == "MiniMax-M3":
+            MINIMAX_MODEL = getenv("MINIMAX_MODEL", "MiniMax-M3")
+        if not MINIMAX_API_URI or MINIMAX_API_URI == API_URIS["global_en"]:
+            MINIMAX_API_URI = getenv(
+                "MINIMAX_API_URI",
+                getenv("MINIMAX_BASE_URI", API_URIS["global_en"]),
+            )
+
+        self.MINIMAX_API_KEY = MINIMAX_API_KEY
+        self.AI_MODEL = MINIMAX_MODEL or "MiniMax-M3"
+        self.API_URI = (
+            API_URIS.get(MINIMAX_API_URI, MINIMAX_API_URI or API_URIS["global_en"])
+            .strip()
+            .rstrip("/")
+        )
+        self.MAX_TOKENS = (
+            int(MINIMAX_MAX_TOKENS)
+            if MINIMAX_MAX_TOKENS
+            else MODEL_CONTEXT_WINDOWS.get(self.AI_MODEL, 32_000)
+        )
+        model_context_window = MODEL_CONTEXT_WINDOWS.get(self.AI_MODEL)
+        if self.MAX_TOKENS <= 0:
+            raise ValueError("MINIMAX_MAX_TOKENS must be positive")
+        if model_context_window and self.MAX_TOKENS > model_context_window:
+            raise ValueError(
+                f"MINIMAX_MAX_TOKENS exceeds the {self.AI_MODEL} context window"
+            )
+        self.MAX_OUTPUT_TOKENS = (
+            int(MINIMAX_MAX_OUTPUT_TOKENS) if MINIMAX_MAX_OUTPUT_TOKENS else 4096
+        )
+        self.AI_TEMPERATURE = float(MINIMAX_TEMPERATURE)
+        if not 0 <= self.AI_TEMPERATURE <= 2:
+            raise ValueError("MINIMAX_TEMPERATURE must be between 0 and 2")
+        self.AI_TOP_P = (
+            float(MINIMAX_TOP_P)
+            if MINIMAX_TOP_P not in (None, "")
+            else MODEL_TOP_P_DEFAULTS.get(self.AI_MODEL, 0.95)
+        )
+        if not 0 <= self.AI_TOP_P <= 1:
+            raise ValueError("MINIMAX_TOP_P must be between 0 and 1")
+        if not 0 < self.MAX_OUTPUT_TOKENS <= self.MAX_TOKENS:
+            raise ValueError(
+                "MINIMAX_MAX_OUTPUT_TOKENS must be positive and fit the context window"
+            )
+
+        requested_thinking = str(MINIMAX_THINKING or "adaptive").strip().lower()
+        if requested_thinking not in ("adaptive", "disabled"):
+            raise ValueError("MINIMAX_THINKING must be adaptive or disabled")
+        if self.AI_MODEL == "MiniMax-M2.7":
+            if requested_thinking == "disabled":
+                raise ValueError("MiniMax-M2.7 thinking cannot be disabled")
+            self.THINKING = "always_on"
+        else:
+            self.THINKING = requested_thinking
+        self.SERVICE_TIER = str(MINIMAX_SERVICE_TIER or "standard").strip().lower()
+        if self.SERVICE_TIER not in ("standard", "priority"):
+            raise ValueError("MINIMAX_SERVICE_TIER must be standard or priority")
+        if self.AI_MODEL != "MiniMax-M3" and self.SERVICE_TIER != "standard":
+            raise ValueError("Priority service is only available with MiniMax-M3")
+
+        self.WAIT_BETWEEN_REQUESTS = (
+            int(MINIMAX_WAIT_BETWEEN_REQUESTS) if MINIMAX_WAIT_BETWEEN_REQUESTS else 0
+        )
+        self.WAIT_AFTER_FAILURE = (
+            int(MINIMAX_WAIT_AFTER_FAILURE) if MINIMAX_WAIT_AFTER_FAILURE else 3
+        )
+        self.failures = 0
+        self.configured = bool(
+            self.MINIMAX_API_KEY
+            and self.MINIMAX_API_KEY.strip()
+            and self.MINIMAX_API_KEY.lower()
+            not in ("your_minimax_api_key", "none", "null", "false", "0")
+        )
+        self.commands = {
+            "Generate Response with MiniMax": self.generate_response_command,
+        }
+
+        if self.configured:
+            self.ApiClient = kwargs.get("ApiClient")
+
+    def services(self):
+        if self.AI_MODEL == "MiniMax-M3":
+            return ["llm", "vision"]
+        return ["llm"]
+
+    def get_max_tokens(self):
+        return self.MAX_TOKENS
+
+    def is_configured(self):
+        return self.configured
+
+    async def inference(
+        self,
+        prompt: str,
+        tokens: int = 0,
+        images: list = [],
+        stream: bool = False,
+        use_smartest: bool = False,
+    ) -> str:
+        if not self.configured:
+            raise Exception("MiniMax provider not configured")
+        if images and self.AI_MODEL != "MiniMax-M3":
+            raise ValueError(f"{self.AI_MODEL} does not support multimodal input")
+
+        messages = []
+        if images:
+            content = [{"type": "text", "text": prompt}]
+            content.extend(_media_content_part(media) for media in images)
+            messages.append({"role": "user", "content": content})
+        else:
+            messages.append({"role": "user", "content": prompt})
+
+        if self.WAIT_BETWEEN_REQUESTS > 0:
+            time.sleep(self.WAIT_BETWEEN_REQUESTS)
+
+        payload = {
+            "model": self.AI_MODEL,
+            "messages": messages,
+            "temperature": self.AI_TEMPERATURE,
+            "max_completion_tokens": self.MAX_OUTPUT_TOKENS,
+            "top_p": self.AI_TOP_P,
+            "n": 1,
+            "stream": stream,
+            "stop": ["</execute>"],
+        }
+        if self.AI_MODEL == "MiniMax-M3":
+            payload["thinking"] = {"type": self.THINKING}
+            payload["service_tier"] = self.SERVICE_TIER
+
+        try:
+            response = requests.post(
+                f"{self.API_URI}/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {self.MINIMAX_API_KEY}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+                stream=stream,
+                timeout=300,
+            )
+            response.raise_for_status()
+            self.failures = 0
+            if stream:
+                return parse_sse_stream(response)
+            return response.json()["choices"][0]["message"]["content"]
+        except Exception as error:
+            self.failures += 1
+            logging.info(f"MiniMax API error: {error}")
+            if self.failures >= 3:
+                raise Exception(f"MiniMax API error: too many failures. {error}")
+            if self.WAIT_AFTER_FAILURE > 0:
+                time.sleep(self.WAIT_AFTER_FAILURE)
+            return await self.inference(
+                prompt=prompt,
+                tokens=tokens,
+                images=images,
+                stream=stream,
+                use_smartest=use_smartest,
+            )
+
+    async def generate_response_command(self, prompt: str) -> str:
+        """Generate a response with MiniMax."""
+        return await self.inference(prompt=prompt)

--- a/agixt/extensions/minimax.py
+++ b/agixt/extensions/minimax.py
@@ -35,6 +35,10 @@ MODEL_OUTPUT_TOKEN_DEFAULTS = {
     "MiniMax-M3": 131_072,
     "MiniMax-M2.7": 65_536,
 }
+MODEL_OUTPUT_TOKEN_LIMITS = {
+    "MiniMax-M3": 524_288,
+    "MiniMax-M2.7": 204_800,
+}
 MODEL_TOP_P_DEFAULTS = {
     "MiniMax-M3": 0.95,
     "MiniMax-M2.7": 0.9,
@@ -47,7 +51,7 @@ MEDIA_TYPES = {
     ".webp": ("image_url", "image/webp"),
     ".mp4": ("video_url", "video/mp4"),
     ".avi": ("video_url", "video/x-msvideo"),
-    ".mov": ("video_url", "video/quicktime"),
+    ".mov": ("video_url", "video/mov"),
     ".mkv": ("video_url", "video/x-matroska"),
 }
 
@@ -233,6 +237,14 @@ class minimax(Extensions):
             if MINIMAX_MAX_OUTPUT_TOKENS
             else MODEL_OUTPUT_TOKEN_DEFAULTS.get(self.AI_MODEL, 4096)
         )
+        model_output_token_limit = MODEL_OUTPUT_TOKEN_LIMITS.get(self.AI_MODEL)
+        if (
+            model_output_token_limit
+            and self.MAX_OUTPUT_TOKENS > model_output_token_limit
+        ):
+            raise ValueError(
+                f"MINIMAX_MAX_OUTPUT_TOKENS exceeds the {self.AI_MODEL} output limit"
+            )
         self.AI_TEMPERATURE = float(MINIMAX_TEMPERATURE)
         if not 0 <= self.AI_TEMPERATURE <= 2:
             raise ValueError("MINIMAX_TEMPERATURE must be between 0 and 2")

--- a/agixt/extensions/minimax.py
+++ b/agixt/extensions/minimax.py
@@ -1,10 +1,11 @@
 """
 MiniMax AI provider extension for AGiXT.
 
-This extension uses the MiniMax chat completions API for text, image, and video
-inference. Set MINIMAX_API_URI to global_en, cn_zh, or a custom compatible base
-URL. API keys are available from https://platform.minimax.io/ and
-https://platform.minimaxi.com/.
+This extension supports MiniMax text, image, and video inference through the
+OpenAI-compatible Chat Completions API and the Anthropic-compatible Messages
+API. Set MINIMAX_API_URI to global_en or cn_zh for Chat Completions, or to
+global_en_anthropic or cn_zh_anthropic for Messages. Custom Anthropic base URLs
+must end in /anthropic; the adapter appends /v1/messages.
 """
 
 import base64
@@ -22,10 +23,16 @@ from Globals import getenv
 API_URIS = {
     "global_en": "https://api.minimax.io/v1",
     "cn_zh": "https://api.minimaxi.com/v1",
+    "global_en_anthropic": "https://api.minimax.io/anthropic",
+    "cn_zh_anthropic": "https://api.minimaxi.com/anthropic",
 }
 MODEL_CONTEXT_WINDOWS = {
     "MiniMax-M3": 1_000_000,
     "MiniMax-M2.7": 204_800,
+}
+MODEL_OUTPUT_TOKEN_DEFAULTS = {
+    "MiniMax-M3": 131_072,
+    "MiniMax-M2.7": 65_536,
 }
 MODEL_TOP_P_DEFAULTS = {
     "MiniMax-M3": 0.95,
@@ -70,8 +77,8 @@ class StreamDelta:
         self.role = delta_data.get("role")
 
 
-def parse_sse_stream(response):
-    """Parse a server-sent event response into AGiXT stream chunks."""
+def _sse_payloads(response):
+    """Yield JSON payloads from a server-sent event response."""
     for line in response.iter_lines():
         if not line:
             continue
@@ -82,9 +89,38 @@ def parse_sse_stream(response):
         if data_text == "[DONE]":
             break
         try:
-            yield StreamChunk(json.loads(data_text))
+            yield json.loads(data_text)
         except json.JSONDecodeError:
             continue
+
+
+def parse_sse_stream(response):
+    """Parse an OpenAI-compatible stream into AGiXT stream chunks."""
+    for data in _sse_payloads(response):
+        yield StreamChunk(data)
+
+
+def parse_anthropic_sse_stream(response):
+    """Parse an Anthropic-compatible stream into AGiXT stream chunks."""
+    for data in _sse_payloads(response):
+        event_type = data.get("type")
+        if event_type == "content_block_delta":
+            delta = data.get("delta", {})
+            if delta.get("type") == "text_delta":
+                chunk_delta = {"content": delta.get("text")}
+            elif delta.get("type") == "thinking_delta":
+                chunk_delta = {"reasoning_content": delta.get("thinking")}
+            else:
+                continue
+            yield StreamChunk(
+                {"choices": [{"delta": chunk_delta, "finish_reason": None}]}
+            )
+        elif event_type == "message_delta":
+            finish_reason = data.get("delta", {}).get("stop_reason")
+            if finish_reason:
+                yield StreamChunk(
+                    {"choices": [{"delta": {}, "finish_reason": finish_reason}]}
+                )
 
 
 def _media_type(media: str):
@@ -102,7 +138,7 @@ def _media_type(media: str):
     raise ValueError(f"Unsupported MiniMax media type: {media}")
 
 
-def _media_content_part(media: str):
+def _media_content_part(media: str, protocol: str):
     content_type, mime_type = _media_type(media)
     if media.startswith(("http://", "https://", "data:", "mm_file://")):
         media_url = media
@@ -110,11 +146,32 @@ def _media_content_part(media: str):
         with open(media, "rb") as media_file:
             encoded_media = base64.b64encode(media_file.read()).decode("utf-8")
         media_url = f"data:{mime_type};base64,{encoded_media}"
+
+    if protocol == "anthropic":
+        block_type = "image" if content_type == "image_url" else "video"
+        if media_url.startswith("data:"):
+            header, encoded_media = media_url.split(",", 1)
+            if not header.endswith(";base64"):
+                raise ValueError("MiniMax data URLs must use base64 encoding")
+            source = {
+                "type": "base64",
+                "media_type": header.removeprefix("data:").removesuffix(";base64"),
+                "data": encoded_media,
+            }
+        else:
+            source = {"type": "url", "url": media_url}
+        return {"type": block_type, "source": source}
+
     return {"type": content_type, content_type: {"url": media_url}}
 
 
 class minimax(Extensions):
-    """MiniMax provider for language and multimodal inference."""
+    """MiniMax provider with regional Chat Completions and Messages endpoints.
+
+    Use global_en or cn_zh for the OpenAI-compatible protocol. Use
+    global_en_anthropic or cn_zh_anthropic for the Anthropic-compatible
+    protocol. A blank thinking setting keeps each protocol's native default.
+    """
 
     CATEGORY = "AI Provider"
     friendly_name = "MiniMax"
@@ -126,10 +183,10 @@ class minimax(Extensions):
         MINIMAX_MODEL: str = "MiniMax-M3",
         MINIMAX_API_URI: str = API_URIS["global_en"],
         MINIMAX_MAX_TOKENS: int = 0,
-        MINIMAX_MAX_OUTPUT_TOKENS: int = 4096,
+        MINIMAX_MAX_OUTPUT_TOKENS: int = 0,
         MINIMAX_TEMPERATURE: float = 1.0,
         MINIMAX_TOP_P: float = None,
-        MINIMAX_THINKING: str = "adaptive",
+        MINIMAX_THINKING: str = "",
         MINIMAX_SERVICE_TIER: str = "standard",
         MINIMAX_WAIT_BETWEEN_REQUESTS: int = 0,
         MINIMAX_WAIT_AFTER_FAILURE: int = 3,
@@ -152,6 +209,12 @@ class minimax(Extensions):
             .strip()
             .rstrip("/")
         )
+        api_path = urlsplit(self.API_URI).path.rstrip("/")
+        if api_path.endswith(("/anthropic/v1", "/anthropic/v1/messages")):
+            raise ValueError(
+                "MINIMAX_API_URI Anthropic base URLs must end in /anthropic"
+            )
+        self.API_PROTOCOL = "anthropic" if api_path.endswith("/anthropic") else "openai"
         self.MAX_TOKENS = (
             int(MINIMAX_MAX_TOKENS)
             if MINIMAX_MAX_TOKENS
@@ -165,7 +228,9 @@ class minimax(Extensions):
                 f"MINIMAX_MAX_TOKENS exceeds the {self.AI_MODEL} context window"
             )
         self.MAX_OUTPUT_TOKENS = (
-            int(MINIMAX_MAX_OUTPUT_TOKENS) if MINIMAX_MAX_OUTPUT_TOKENS else 4096
+            int(MINIMAX_MAX_OUTPUT_TOKENS)
+            if MINIMAX_MAX_OUTPUT_TOKENS
+            else MODEL_OUTPUT_TOKEN_DEFAULTS.get(self.AI_MODEL, 4096)
         )
         self.AI_TEMPERATURE = float(MINIMAX_TEMPERATURE)
         if not 0 <= self.AI_TEMPERATURE <= 2:
@@ -182,15 +247,13 @@ class minimax(Extensions):
                 "MINIMAX_MAX_OUTPUT_TOKENS must be positive and fit the context window"
             )
 
-        requested_thinking = str(MINIMAX_THINKING or "adaptive").strip().lower()
-        if requested_thinking not in ("adaptive", "disabled"):
-            raise ValueError("MINIMAX_THINKING must be adaptive or disabled")
+        requested_thinking = str(MINIMAX_THINKING or "").strip().lower()
+        if requested_thinking not in ("", "adaptive", "disabled"):
+            raise ValueError("MINIMAX_THINKING must be blank, adaptive, or disabled")
         if self.AI_MODEL == "MiniMax-M2.7":
-            if requested_thinking == "disabled":
-                raise ValueError("MiniMax-M2.7 thinking cannot be disabled")
             self.THINKING = "always_on"
         else:
-            self.THINKING = requested_thinking
+            self.THINKING = requested_thinking or None
         self.SERVICE_TIER = str(MINIMAX_SERVICE_TIER or "standard").strip().lower()
         if self.SERVICE_TIER not in ("standard", "priority"):
             raise ValueError("MINIMAX_SERVICE_TIER must be standard or priority")
@@ -217,10 +280,9 @@ class minimax(Extensions):
         if self.configured:
             self.ApiClient = kwargs.get("ApiClient")
 
-    def services(self):
-        if self.AI_MODEL == "MiniMax-M3":
-            return ["llm", "vision"]
-        return ["llm"]
+    @staticmethod
+    def services():
+        return ["llm", "vision"]
 
     def get_max_tokens(self):
         return self.MAX_TOKENS
@@ -244,8 +306,14 @@ class minimax(Extensions):
         messages = []
         if images:
             content = [{"type": "text", "text": prompt}]
-            content.extend(_media_content_part(media) for media in images)
+            content.extend(
+                _media_content_part(media, self.API_PROTOCOL) for media in images
+            )
             messages.append({"role": "user", "content": content})
+        elif self.API_PROTOCOL == "anthropic":
+            messages.append(
+                {"role": "user", "content": [{"type": "text", "text": prompt}]}
+            )
         else:
             messages.append({"role": "user", "content": prompt})
 
@@ -256,19 +324,26 @@ class minimax(Extensions):
             "model": self.AI_MODEL,
             "messages": messages,
             "temperature": self.AI_TEMPERATURE,
-            "max_completion_tokens": self.MAX_OUTPUT_TOKENS,
             "top_p": self.AI_TOP_P,
-            "n": 1,
             "stream": stream,
-            "stop": ["</execute>"],
         }
+        if self.API_PROTOCOL == "anthropic":
+            payload["max_tokens"] = self.MAX_OUTPUT_TOKENS
+            payload["stop_sequences"] = ["</execute>"]
+            api_url = f"{self.API_URI}/v1/messages"
+        else:
+            payload["max_completion_tokens"] = self.MAX_OUTPUT_TOKENS
+            payload["n"] = 1
+            payload["stop"] = ["</execute>"]
+            api_url = f"{self.API_URI}/chat/completions"
         if self.AI_MODEL == "MiniMax-M3":
-            payload["thinking"] = {"type": self.THINKING}
+            if self.THINKING:
+                payload["thinking"] = {"type": self.THINKING}
             payload["service_tier"] = self.SERVICE_TIER
 
         try:
             response = requests.post(
-                f"{self.API_URI}/chat/completions",
+                api_url,
                 headers={
                     "Authorization": f"Bearer {self.MINIMAX_API_KEY}",
                     "Content-Type": "application/json",
@@ -280,8 +355,17 @@ class minimax(Extensions):
             response.raise_for_status()
             self.failures = 0
             if stream:
+                if self.API_PROTOCOL == "anthropic":
+                    return parse_anthropic_sse_stream(response)
                 return parse_sse_stream(response)
-            return response.json()["choices"][0]["message"]["content"]
+            response_data = response.json()
+            if self.API_PROTOCOL == "anthropic":
+                return "".join(
+                    block.get("text", "")
+                    for block in response_data.get("content", [])
+                    if block.get("type") == "text"
+                )
+            return response_data["choices"][0]["message"]["content"]
         except Exception as error:
             self.failures += 1
             logging.info(f"MiniMax API error: {error}")

--- a/tests/unit/test_minimax.py
+++ b/tests/unit/test_minimax.py
@@ -152,6 +152,29 @@ def test_anthropic_requests_use_native_multimodal_blocks():
     }
 
 
+@pytest.mark.parametrize("protocol", ["openai", "anthropic"])
+def test_local_mov_files_use_the_documented_base64_media_type(tmp_path, protocol):
+    media_file = tmp_path / "clip.mov"
+    media_file.write_bytes(b"video")
+
+    content = minimax_module._media_content_part(str(media_file), protocol)
+
+    if protocol == "anthropic":
+        assert content == {
+            "type": "video",
+            "source": {
+                "type": "base64",
+                "media_type": "video/mov",
+                "data": "dmlkZW8=",
+            },
+        }
+    else:
+        assert content == {
+            "type": "video_url",
+            "video_url": {"url": "data:video/mov;base64,dmlkZW8="},
+        }
+
+
 def test_anthropic_stream_maps_text_reasoning_and_finish_chunks():
     response = FakeResponse(
         lines=[
@@ -188,6 +211,19 @@ def test_target_model_defaults_preserve_context_and_output_semantics():
     )
     assert m3.THINKING is None
     assert m27.THINKING == "always_on"
+
+
+@pytest.mark.parametrize(
+    ("model", "max_output_tokens"),
+    [("MiniMax-M3", 524_289), ("MiniMax-M2.7", 204_801)],
+)
+def test_rejects_output_tokens_above_model_limits(model, max_output_tokens):
+    with pytest.raises(ValueError, match=f"{model} output limit"):
+        minimax_module.minimax(
+            MINIMAX_API_KEY="test-key",
+            MINIMAX_MODEL=model,
+            MINIMAX_MAX_OUTPUT_TOKENS=max_output_tokens,
+        )
 
 
 def test_provider_services_can_be_discovered_from_the_class():

--- a/tests/unit/test_minimax.py
+++ b/tests/unit/test_minimax.py
@@ -97,14 +97,19 @@ def test_routes_requests_to_each_regional_protocol(api_uri, expected_url, protoc
     assert result == "ready"
     assert request.call_args.args[0] == expected_url
     payload = request.call_args.kwargs["json"]
-    assert request.call_args.kwargs["headers"]["Authorization"] == "Bearer test-key"
+    headers = request.call_args.kwargs["headers"]
     assert payload["service_tier"] == "standard"
     assert "thinking" not in payload
     if protocol == "anthropic":
+        assert headers["x-api-key"] == "test-key"
+        assert headers["anthropic-version"] == "2023-06-01"
+        assert "Authorization" not in headers
         assert payload["max_tokens"] == 32
         assert "max_completion_tokens" not in payload
         assert payload["messages"][0]["content"][0]["type"] == "text"
     else:
+        assert headers["Authorization"] == "Bearer test-key"
+        assert "x-api-key" not in headers
         assert payload["max_completion_tokens"] == 32
         assert "max_tokens" not in payload
 

--- a/tests/unit/test_minimax.py
+++ b/tests/unit/test_minimax.py
@@ -1,0 +1,197 @@
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = PROJECT_ROOT / "agixt" / "extensions" / "minimax.py"
+
+
+def _load_minimax_module():
+    extensions_stub = types.ModuleType("Extensions")
+    extensions_stub.Extensions = type("Extensions", (), {})
+    globals_stub = types.ModuleType("Globals")
+    globals_stub.getenv = lambda _name, default="": default
+
+    previous_extensions = sys.modules.get("Extensions")
+    previous_globals = sys.modules.get("Globals")
+    sys.modules["Extensions"] = extensions_stub
+    sys.modules["Globals"] = globals_stub
+    try:
+        spec = importlib.util.spec_from_file_location("minimax_extension", MODULE_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if previous_extensions is None:
+            sys.modules.pop("Extensions", None)
+        else:
+            sys.modules["Extensions"] = previous_extensions
+        if previous_globals is None:
+            sys.modules.pop("Globals", None)
+        else:
+            sys.modules["Globals"] = previous_globals
+
+
+minimax_module = _load_minimax_module()
+
+
+class FakeResponse:
+    def __init__(self, data=None, lines=None):
+        self.data = data or {}
+        self.lines = lines or []
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.data
+
+    def iter_lines(self):
+        return iter(self.lines)
+
+
+@pytest.mark.parametrize(
+    ("api_uri", "expected_url", "protocol"),
+    [
+        ("global_en", "https://api.minimax.io/v1/chat/completions", "openai"),
+        ("cn_zh", "https://api.minimaxi.com/v1/chat/completions", "openai"),
+        (
+            "global_en_anthropic",
+            "https://api.minimax.io/anthropic/v1/messages",
+            "anthropic",
+        ),
+        (
+            "cn_zh_anthropic",
+            "https://api.minimaxi.com/anthropic/v1/messages",
+            "anthropic",
+        ),
+    ],
+)
+def test_routes_requests_to_each_regional_protocol(api_uri, expected_url, protocol):
+    response_data = (
+        {
+            "content": [
+                {"type": "thinking", "thinking": "internal"},
+                {"type": "text", "text": "ready"},
+            ]
+        }
+        if protocol == "anthropic"
+        else {"choices": [{"message": {"content": "ready"}}]}
+    )
+    provider = minimax_module.minimax(
+        MINIMAX_API_KEY="test-key",
+        MINIMAX_API_URI=api_uri,
+        MINIMAX_MAX_OUTPUT_TOKENS=32,
+    )
+
+    with patch.object(
+        minimax_module.requests, "post", return_value=FakeResponse(response_data)
+    ) as request:
+        result = asyncio.run(provider.inference("Hello"))
+
+    assert result == "ready"
+    assert request.call_args.args[0] == expected_url
+    payload = request.call_args.kwargs["json"]
+    assert request.call_args.kwargs["headers"]["Authorization"] == "Bearer test-key"
+    assert payload["service_tier"] == "standard"
+    assert "thinking" not in payload
+    if protocol == "anthropic":
+        assert payload["max_tokens"] == 32
+        assert "max_completion_tokens" not in payload
+        assert payload["messages"][0]["content"][0]["type"] == "text"
+    else:
+        assert payload["max_completion_tokens"] == 32
+        assert "max_tokens" not in payload
+
+
+def test_anthropic_requests_use_native_multimodal_blocks():
+    provider = minimax_module.minimax(
+        MINIMAX_API_KEY="test-key",
+        MINIMAX_API_URI="global_en_anthropic",
+        MINIMAX_MAX_OUTPUT_TOKENS=32,
+    )
+
+    with patch.object(
+        minimax_module.requests,
+        "post",
+        return_value=FakeResponse({"content": [{"type": "text", "text": "ready"}]}),
+    ) as request:
+        asyncio.run(
+            provider.inference(
+                "Inspect these",
+                images=[
+                    "https://example.com/image.png",
+                    "data:image/png;base64,AA==",
+                    "mm_file://video-id",
+                ],
+            )
+        )
+
+    content = request.call_args.kwargs["json"]["messages"][0]["content"]
+    assert content[1] == {
+        "type": "image",
+        "source": {"type": "url", "url": "https://example.com/image.png"},
+    }
+    assert content[2] == {
+        "type": "image",
+        "source": {"type": "base64", "media_type": "image/png", "data": "AA=="},
+    }
+    assert content[3] == {
+        "type": "video",
+        "source": {"type": "url", "url": "mm_file://video-id"},
+    }
+
+
+def test_anthropic_stream_maps_text_reasoning_and_finish_chunks():
+    response = FakeResponse(
+        lines=[
+            b'data: {"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"plan"}}',
+            b'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"answer"}}',
+            b'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}',
+        ]
+    )
+
+    chunks = list(minimax_module.parse_anthropic_sse_stream(response))
+
+    assert chunks[0].choices[0].delta.reasoning_content == "plan"
+    assert chunks[1].choices[0].delta.content == "answer"
+    assert chunks[2].choices[0].finish_reason == "end_turn"
+
+
+def test_target_model_defaults_preserve_context_and_output_semantics():
+    m3 = minimax_module.minimax(MINIMAX_API_KEY="test-key")
+    m27 = minimax_module.minimax(
+        MINIMAX_API_KEY="test-key",
+        MINIMAX_MODEL="MiniMax-M2.7",
+        MINIMAX_THINKING="disabled",
+    )
+
+    assert (m3.MAX_TOKENS, m3.MAX_OUTPUT_TOKENS, m3.AI_TOP_P) == (
+        1_000_000,
+        131_072,
+        0.95,
+    )
+    assert (m27.MAX_TOKENS, m27.MAX_OUTPUT_TOKENS, m27.AI_TOP_P) == (
+        204_800,
+        65_536,
+        0.9,
+    )
+    assert m3.THINKING is None
+    assert m27.THINKING == "always_on"
+
+
+def test_provider_services_can_be_discovered_from_the_class():
+    assert minimax_module.minimax.services() == ["llm", "vision"]
+
+
+def test_rejects_versioned_anthropic_base_urls():
+    with pytest.raises(ValueError, match="must end in /anthropic"):
+        minimax_module.minimax(
+            MINIMAX_API_KEY="test-key",
+            MINIMAX_API_URI="https://api.minimax.io/anthropic/v1",
+        )


### PR DESCRIPTION
# Description

Add a MiniMax AI provider extension for AGiXT language and multimodal inference.

The extension:

- Supports MiniMax-M3 and MiniMax-M2.7 with model-specific context windows, output limits, and sampling defaults.
- Supports global and China API regions through OpenAI-compatible and Anthropic-compatible aliases in the existing `MINIMAX_API_URI` setting.
- Supports MiniMax-M3 text, image, and video input, configurable thinking, and standard or priority service.
- Keeps MiniMax-M2.7 text-only with always-on thinking.
- Preserves each protocol's native thinking default when no explicit mode is configured.
- Separates the model context window from the request generation limit.
- Exposes the class-level service metadata required by provider discovery.

## Motivation and Context

Make MiniMax available to AGiXT provider rotation with verified model defaults, regional endpoints, and protocol-specific request handling.

## How has this been tested?

- `python3.11 -m py_compile agixt/extensions/minimax.py tests/unit/test_minimax.py`
- `uvx black --check agixt/extensions/minimax.py tests/unit/test_minimax.py`
- `uvx ruff check agixt/extensions/minimax.py tests/unit/test_minimax.py`
- `uvx --with requests pytest -q tests/unit/test_minimax.py` (`13 passed`)
- Target coverage checks against the official model and endpoint documentation.
- Request-capture tests for both regions and protocols, multimodal payloads, streaming chunks, and provider discovery.

## Types of changes

Changes visible to users:

- [ ] **Bug fix**
- [x] **New feature**
- [ ] **Breaking change**

Internal changes:

- [ ] **Refactor**
- [x] **Tests**
- [ ] **Infrastructure**

## Checklist

- [ ] My change requires a change to the documentation.
- [x] My change works!

